### PR TITLE
update(template): Adding init command to the Getting Started Section , and also added `>` to every Note 

### DIFF
--- a/.github/instructions/readme-markdown.instructions.md
+++ b/.github/instructions/readme-markdown.instructions.md
@@ -90,10 +90,18 @@ If a section is irrelevant (e.g., no error handling), the empty stub should be n
     - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
     - Linux: Distributions such as Ubuntu 20.04 or later, Debian 10 or later, or Amazon Linux 2 or later (arm64 or x86_64)
   ```   
-* **Getting started** → Must include link to Connector SDK Setup Guide. It is a fixed content, verbatim (no edits or omissions), as provided below:
+* **Getting started** → Must include link to Connector SDK Setup Guide and the `fivetran init` command. It is a fixed content, verbatim (no edits or omissions), as provided below:
   ```markdown
   ## Getting started
   Refer to the [Connector SDK Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
+
+  To initialize a new Connector SDK project using this connector as a starting point, run:
+
+  ```
+  fivetran init --template <connector-name>
+  ```
+
+  `fivetran init` initializes a new Connector SDK project by setting up the project structure, configuration files, and a connector you can run immediately with `fivetran debug`. For more information on `fivetran init`, refer to the [Connector SDK init documentation](https://fivetran.com/docs/connectors/connector-sdk/technical-reference/init).
   ```
 * **Features** → Must list concrete features (not left blank or italicized template text).
 * **Configuration file** → Must include a JSON code block showing keys. Must mention that `configuration.json` should not be versioned, for example, as provided below:
@@ -124,7 +132,7 @@ If a section is irrelevant (e.g., no error handling), the empty stub should be n
   redshift_connector
   ```
 
-  Note: The `fivetran_connector_sdk:latest` and `requests:latest` packages are pre-installed in the Fivetran environment. To avoid dependency conflicts, do not declare them in your `requirements.txt`.
+  Note: The `fivetran_connector_sdk:latest`, `requests:2.33.0`, `grpcio:1.78.0`, and `grpcio-tools:1.78.0` packages are pre-installed in the Fivetran environment. To avoid dependency conflicts, do not declare them in your `requirements.txt`.
   ```
 * **Authentication** → Must specify auth method (API key, OAuth2, etc). For example, as provided below:
   ```markdown

--- a/_template_connector/README_template.md
+++ b/_template_connector/README_template.md
@@ -56,7 +56,7 @@ To initialize a new Connector SDK project using this connector as a starting poi
 fivetran init --template <connector-name>
 ```
 
-`fivetran init` initializes a new Connector SDK project by setting up the project structure, configuration files, and a connector you can run immediately with `fivetran debug`. If you do not specify a project path, Fivetran creates the project in your current directory. For more information on `fivetran init`, refer to the [Connector SDK init documentation](https://fivetran.com/docs/connectors/connector-sdk/technical-reference/init).
+`fivetran init` initializes a new Connector SDK project by setting up the project structure, configuration files, and a connector you can run immediately with `fivetran debug`. For more information on `fivetran init`, refer to the [Connector SDK init documentation](https://fivetran.com/docs/connectors/connector-sdk/technical-reference/init).
 
 *Include the following note only if the connector requires a `configuration.json` file to run.*
 

--- a/_template_connector/README_template.md
+++ b/_template_connector/README_template.md
@@ -14,7 +14,7 @@
 *Do not use Title Case in plain text that is used as unformatted subheading or item title, only capitalize the first word of subheading/item title (e.g., \- Rate limit errors – The connector automatically retries with exponential backoff, \- Data volume – Large accounts may require longer sync times, Incremental sync:).*
 *Do not use **bold** text anywhere except for UI elements controls like tabs, menus, buttons, fields, etc.*
 *Do not use nested bulleted lists for descriptions - write the description inline, for example, "- `mock\_api.py` – A simulated API for testing data retrieval."*
-*Use the following format for notes: "Note: note text"; omit the double quotes.*
+*Use the following format for notes: "> Note: note text"; omit the double quotes.*
 *Use numbered lists only where the order is important, for example, for a sequence of user actions. Every item in numbered lists should end with full stop.*
 *Complex sequences of user actions should use numbers for parent items and Roman notation for child items, with blank lines between the lines with Roman numerals.*
 *Use bulleted lists where the items are listed without any particular order or where alternatives are presented.*
@@ -50,6 +50,18 @@ This example was contributed by [Contributor Name/Organization](link-to-profile-
 ## Getting started
 Refer to the [Connector SDK Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
 
+To initialize a new Connector SDK project using this connector as a starting point, run:
+
+```
+fivetran init <project-path> --template connectors/<connector-name>
+```
+
+`fivetran init` initializes a new Connector SDK project by setting up the project structure, configuration files, and a connector you can run immediately with `fivetran debug`. If you do not specify a project path, Fivetran creates the project in your current directory. For more information on `fivetran init`, refer to the [Connector SDK init documentation](https://fivetran.com/docs/connectors/connector-sdk/technical-reference/init).
+
+*Include the following note only if the connector requires a `configuration.json` file to run.*
+
+> Note: Ensure you have updated the `configuration.json` file with the necessary parameters before running `fivetran debug`. See the [Configuration file](#configuration-file) section for details on the required configuration parameters.
+
 
 ## Features
 - *List key features of the connector, such as supported endpoints, data replication methods, and any special capabilities.*
@@ -66,8 +78,7 @@ Refer to the [Connector SDK Setup Guide](https://fivetran.com/docs/connectors/co
 }
 ```
 
-Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main/connectors) or enhancing an [example](https://github.com/fivetran/fivetran-csdk-connectors/tree/main/examples) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values.
-When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main/connectors) or enhancing an [example](https://github.com/fivetran/fivetran-csdk-connectors/tree/main/examples) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 
 ## Requirements file
@@ -79,7 +90,7 @@ When adding the connector to your production repository, ensure that the `config
 pandas
 ```
 
-Note: The `fivetran_connector_sdk:latest` and `requests:latest` packages are pre-installed in the Fivetran environment. To avoid dependency conflicts, do not declare them in your `requirements.txt`.
+> Note: The `fivetran_connector_sdk:latest` and `requests:latest` packages are pre-installed in the Fivetran environment. To avoid dependency conflicts, do not declare them in your `requirements.txt`.
 
 
 ## Authentication

--- a/_template_connector/README_template.md
+++ b/_template_connector/README_template.md
@@ -90,7 +90,7 @@ fivetran init --template <connector-name>
 pandas
 ```
 
-> Note: The `fivetran_connector_sdk:latest` and `requests:latest` packages are pre-installed in the Fivetran environment. To avoid dependency conflicts, do not declare them in your `requirements.txt`.
+> Note: The `fivetran_connector_sdk:latest`, `requests:2.33.0`, `grpcio:1.78.0`, and `grpcio-tools:1.78.0` packages are pre-installed in the Fivetran environment. To avoid dependency conflicts, do not declare them in your `requirements.txt`.
 
 
 ## Authentication

--- a/_template_connector/README_template.md
+++ b/_template_connector/README_template.md
@@ -53,7 +53,7 @@ Refer to the [Connector SDK Setup Guide](https://fivetran.com/docs/connectors/co
 To initialize a new Connector SDK project using this connector as a starting point, run:
 
 ```
-fivetran init <project-path> --template connectors/<connector-name>
+fivetran init --template <connector-name>
 ```
 
 `fivetran init` initializes a new Connector SDK project by setting up the project structure, configuration files, and a connector you can run immediately with `fivetran debug`. If you do not specify a project path, Fivetran creates the project in your current directory. For more information on `fivetran init`, refer to the [Connector SDK init documentation](https://fivetran.com/docs/connectors/connector-sdk/technical-reference/init).

--- a/_template_connector/README_template.md
+++ b/_template_connector/README_template.md
@@ -78,7 +78,7 @@ fivetran init --template <connector-name>
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main/connectors) or enhancing an [example](https://github.com/fivetran/fivetran-csdk-connectors/tree/main/examples) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 
 ## Requirements file

--- a/_template_connector/README_template.md
+++ b/_template_connector/README_template.md
@@ -78,7 +78,7 @@ fivetran init --template <connector-name>
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 
 ## Requirements file

--- a/_template_connector/requirements.txt
+++ b/_template_connector/requirements.txt
@@ -4,8 +4,9 @@
 # Example:
 # pandas==2.0.3
 #
-# Note: fivetran_connector_sdk and requests are pre-installed in the base environment
-# and should not be included in this file.
+# Note: The following packages are pre-installed in the base environment
+# and should not be included in this file:
+#   fivetran_connector_sdk:latest, requests:2.33.0, grpcio:1.78.0, grpcio-tools:1.78.0
 #
 # Best practices:
 # - Use explicit versions (==) for reproducibility


### PR DESCRIPTION

Closes [RD-1188475](https://fivetran.atlassian.net/browse/RD-1188475)

### Description of Change
- Add fivetran init command with `--template` usage, description, and init docs link
- Add conditional note for configuration.json requirement
- Convert all Note: entries to > blockquote format per updated style guide

### Testing
No Testing

### Checklist
Some tips and links to help validate your PR:

- [ ] Tested the connector with `fivetran debug` command.
- [ ] Added/Updated example-specific README.md file, see [the README template](https://github.com/fivetran/fivetran-csdk-connectors/tree/main/_template_connector/README_template.md) for the required structure and guidelines.
- [ ] Followed Python Coding Standards, [refer here](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/PYTHON_CODING_STANDARDS.md)