### PR TITLE
fix(connector_sdk) : Changes the init link 

### DIFF
--- a/.github/instructions/readme-markdown.instructions.md
+++ b/.github/instructions/readme-markdown.instructions.md
@@ -101,7 +101,7 @@ If a section is irrelevant (e.g., no error handling), the empty stub should be n
   fivetran init --template <connector-name>
   ```
 
-  `fivetran init` initializes a new Connector SDK project by setting up the project structure, configuration files, and a connector you can run immediately with `fivetran debug`. For more information on `fivetran init`, refer to the [Connector SDK init documentation](https://fivetran.com/docs/connectors/connector-sdk/technical-reference/init).
+  `fivetran init` initializes a new Connector SDK project by setting up the project structure, configuration files, and a connector you can run immediately with `fivetran debug`. For more information on `fivetran init`, refer to the [Connector SDK init documentation](https://fivetran.com/docs/connector-sdk/connector-development-and-configuration/connector-sdk-commands#fivetraninit).
   ```
 * **Features** → Must list concrete features (not left blank or italicized template text).
 * **Configuration file** → Must include a JSON code block showing keys. Must mention that `configuration.json` should not be versioned, for example, as provided below:

--- a/.github/instructions/readme-markdown.instructions.md
+++ b/.github/instructions/readme-markdown.instructions.md
@@ -101,7 +101,7 @@ If a section is irrelevant (e.g., no error handling), the empty stub should be n
   fivetran init --template <connector-name>
   ```
 
-  `fivetran init` initializes a new Connector SDK project by setting up the project structure, configuration files, and a connector you can run immediately with `fivetran debug`. For more information on `fivetran init`, refer to the [Connector SDK init documentation](https://fivetran.com/docs/connector-sdk/connector-development-and-configuration/connector-sdk-commands#fivetraninit).
+  `fivetran init` initializes a new Connector SDK project by setting up the project structure, configuration files, and a connector you can run immediately with `fivetran debug`. For more information on `fivetran init`, refer to the [Connector SDK `init` documentation](https://fivetran.com/docs/connector-sdk/connector-development-and-configuration/connector-sdk-commands#fivetraninit).
   ```
 * **Features** → Must list concrete features (not left blank or italicized template text).
 * **Configuration file** → Must include a JSON code block showing keys. Must mention that `configuration.json` should not be versioned, for example, as provided below:

--- a/_template_connector/README_template.md
+++ b/_template_connector/README_template.md
@@ -56,7 +56,7 @@ To initialize a new Connector SDK project using this connector as a starting poi
 fivetran init --template <connector-name>
 ```
 
-`fivetran init` initializes a new Connector SDK project by setting up the project structure, configuration files, and a connector you can run immediately with `fivetran debug`. For more information on `fivetran init`, refer to the [Connector SDK init documentation](https://fivetran.com/docs/connectors/connector-sdk/technical-reference/init).
+`fivetran init` initializes a new Connector SDK project by setting up the project structure, configuration files, and a connector you can run immediately with `fivetran debug`. For more information on `fivetran init`, refer to the [Connector SDK `init` documentation](https://fivetran.com/docs/connector-sdk/setup-guide#createyourcustomconnector).
 
 *Include the following note only if the connector requires a `configuration.json` file to run.*
 

--- a/_template_connector/README_template.md
+++ b/_template_connector/README_template.md
@@ -56,7 +56,7 @@ To initialize a new Connector SDK project using this connector as a starting poi
 fivetran init --template <connector-name>
 ```
 
-`fivetran init` initializes a new Connector SDK project by setting up the project structure, configuration files, and a connector you can run immediately with `fivetran debug`. For more information on `fivetran init`, refer to the [Connector SDK `init` documentation](https://fivetran.com/docs/connector-sdk/setup-guide#createyourcustomconnector).
+`fivetran init` initializes a new Connector SDK project by setting up the project structure, configuration files, and a connector you can run immediately with `fivetran debug`. For more information on `fivetran init`, refer to the [Connector SDK `init` documentation](https://fivetran.com/docs/connector-sdk/connector-development-and-configuration/connector-sdk-commands#fivetraninit).
 
 *Include the following note only if the connector requires a `configuration.json` file to run.*
 


### PR DESCRIPTION
### Description of Change
Made a small link change for the init command line 
### Testing
No testing
### Checklist
Some tips and links to help validate your PR:

- [ ] Tested the connector with `fivetran debug` command.
- [ ] Added/Updated example-specific README.md file, see [the README template](https://github.com/fivetran/fivetran-csdk-connectors/tree/main/_template_connector/README_template.md) for the required structure and guidelines.
- [ ] Followed Python Coding Standards, [refer here](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/PYTHON_CODING_STANDARDS.md)