### PR TITLE
docs(connector_SDK): Updating the links and converting links to absolute links

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,5 +8,5 @@
 Some tips and links to help validate your PR:
 
 - [ ] Tested the connector with `fivetran debug` command.
-- [ ] Added/Updated example-specific README.md file, see [the README template](https://github.com/fivetran/fivetran-csdk-connectors/tree/main/_template_connector/README_template.md) for the required structure and guidelines.
-- [ ] Followed Python Coding Standards, [refer here](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/PYTHON_CODING_STANDARDS.md)
+- [ ] Added/Updated example-specific README.md file, see [the README template](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/_template_connector/README_template.md) for the required structure and guidelines.
+- [ ] Followed Python Coding Standards, [refer here](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/PYTHON_CODING_STANDARDS.md)

--- a/.github/instructions/configuration-review.instructions.md
+++ b/.github/instructions/configuration-review.instructions.md
@@ -10,7 +10,7 @@ When a PR changes or adds a connector/example/template that includes a `configur
 ## JSON Structure and Syntax (BLOCKER if violated)
 - **Valid JSON**: File must parse correctly as valid JSON (no trailing commas, proper quotes, balanced braces)
 - **Root object**: Configuration must be a JSON object `{}`, not an array or primitive
-- **Template compliance**: Follow the structure in [template configuration.json](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/_template_connector/configuration.json)
+- **Template compliance**: Follow the structure in [template configuration.json](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/_template_connector/configuration.json)
 
 ## Key Naming Conventions (REQUEST_CHANGES if violated)
 - **Descriptive names**: Keys must clearly describe their purpose (e.g., `api_key`, `database_url`, `max_retries`)

--- a/.github/instructions/readme-markdown.instructions.md
+++ b/.github/instructions/readme-markdown.instructions.md
@@ -84,7 +84,7 @@ If a section is irrelevant (e.g., no error handling), the empty stub should be n
 * **Requirements** → Must list OS and Python versions. Use provided bullet format. It is a fixed content, verbatim (no edits or omissions), as provided below:
   ```markdown
   ## Requirements
-  - [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)   
+  - [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)   
   - Operating system:
     - Windows: 10 or later (64-bit only)
     - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing to the Fivetran Connector SDK. This 
 
 ## Code of conduct
 
-This project adheres to the [Contributor Covenant Code of Conduct](https://github.com/fivetran/fivetran-csdk-connectors/tree/main/CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
+This project adheres to the [Contributor Covenant Code of Conduct](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
 
 ## Ways to contribute
 
@@ -21,7 +21,7 @@ We encourage the community to contribute in the following ways:
 Before contributing, do the following:
 
 1. Familiarize yourself with the [Connector SDK documentation](https://fivetran.com/docs/connector-sdk).
-2. Browse the [existing examples](https://github.com/fivetran/fivetran-csdk-connectors/tree/main/README.md#examples) to understand our coding patterns and structure.
+2. Browse the [existing examples](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/README.md#examples) to understand our coding patterns and structure.
 3. Set up your environment - follow the [setup guide](https://fivetran.com/docs/connector-sdk/setup-guide) to install the Connector SDK.
 
 
@@ -29,7 +29,7 @@ Before contributing, do the following:
 
 ### Step 1: Fork the repository
 
-1. Navigate to the [Fivetran Connector SDK Connectors repository](https://github.com/fivetran/fivetran-csdk-connectors) on GitHub.
+1. Navigate to the [Fivetran Connector SDK Connectors repository](https://github.com/fivetran/fivetran_csdk_connectors) on GitHub.
 2. Click **Fork** in the upper-right corner of the page.
 3. This creates a copy of the repository under your GitHub account.
 
@@ -37,13 +37,13 @@ Before contributing, do the following:
 
 ```bash
 # Clone your forked repository to your local machine
-git clone https://github.com/<YOUR_USERNAME>/fivetran-csdk-connectors.git
+git clone https://github.com/<YOUR_USERNAME>/fivetran_csdk_connectors.git
 
 # Navigate to the repository directory
-cd fivetran-csdk-connectors
+cd fivetran_csdk_connectors
 
 # Add the original repository as an upstream remote
-git remote add upstream https://github.com/fivetran/fivetran-csdk-connectors.git
+git remote add upstream https://github.com/fivetran/fivetran_csdk_connectors.git
 ```
 
 ### Step 3: Set up pre-commit hooks
@@ -106,7 +106,7 @@ git push
 
 1. Navigate to your forked repository on GitHub.
 2. Click the `Compare & pull request` button.
-3. Ensure the base repository is `fivetran/fivetran-csdk-connectors` and the base branch is `main`.
+3. Ensure the base repository is `fivetran/fivetran_csdk_connectors` and the base branch is `main`.
 4. Fill out the pull request template with:
    - Clear title message
    - Detailed description of your changes
@@ -137,8 +137,8 @@ All contributions must adhere to our coding standards and principles to ensure c
 
 Before submitting a pull request, thoroughly review these documents:
 
-- [Python Coding Standards](https://github.com/fivetran/fivetran-csdk-connectors/tree/main/PYTHON_CODING_STANDARDS.md) - comprehensive guidelines for Python code style, naming conventions, and best practices
-- [Fivetran Coding Principles](https://github.com/fivetran/fivetran-csdk-connectors/tree/main/FIVETRAN_CODING_PRINCIPLES.md) - high-level principles for code reviews, PR guidelines, and example development
+- [Python Coding Standards](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/PYTHON_CODING_STANDARDS.md) - comprehensive guidelines for Python code style, naming conventions, and best practices
+- [Fivetran Coding Principles](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/FIVETRAN_CODING_PRINCIPLES.md) - high-level principles for code reviews, PR guidelines, and example development
 - [Connector SDK Best Practices](https://fivetran.com/docs/connector-sdk/best-practices) - official documentation on best practices
 
 ### Documentation requirements
@@ -147,11 +147,11 @@ Every new connector example contribution must include proper documentation:
 
 #### README.md
 
-Each new connector example must include a `README.md` file in its directory. Refer to the [template connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main/_template_connector) for structure and formatting.
+Each new connector example must include a `README.md` file in its directory. Refer to the [template connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/_template_connector) for structure and formatting.
 
 #### Root README.md update
 
-When adding a new connector example, you must update the root [README.md](https://github.com/fivetran/fivetran-csdk-connectors/tree/main/README.md) file to include your example in the appropriate section.
+When adding a new connector example, you must update the root [README.md](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/README.md) file to include your example in the appropriate section.
 
 
 ## Review process
@@ -262,7 +262,7 @@ What to update in `README.md`:
 
 ### 3. Contributor license agreement
 
-All contributors must sign the Fivetran CLA before their contributions can be accepted. You can review the CLA [here](https://cla-assistant.io/fivetran/fivetran-csdk-connectors).
+All contributors must sign the Fivetran CLA before their contributions can be accepted. You can review the CLA [here](https://cla-assistant.io/fivetran/fivetran_csdk_connectors).
 
 #### How the CLA works
 

--- a/FIVETRAN_CODING_PRINCIPLES.md
+++ b/FIVETRAN_CODING_PRINCIPLES.md
@@ -74,7 +74,7 @@ To adhere to Fivetran engineering standards, follow this process:
 ### 4.1 Template connector
 
 A reference implementation is available here:
-[Fivetran Connector SDK Template Example](https://github.com/fivetran/fivetran-csdk-connectors/tree/main/_template_connector)
+[Fivetran Connector SDK Template Example](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/_template_connector)
 
 This includes:
 - A `connector.py` template.

--- a/PYTHON_CODING_STANDARDS.md
+++ b/PYTHON_CODING_STANDARDS.md
@@ -468,6 +468,6 @@ __BASE_DELAY = 1  # Base delay in seconds for API request retries
 
 ## Templates
 
-Refer to our `connector.py` and `README_template.md` files in this repo ([https://github.com/fivetran/fivetran-csdk-connectors/tree/main/_template_connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main/_template_connector)).
+Refer to our `connector.py` and `README_template.md` files in this repo ([https://github.com/fivetran/fivetran_csdk_connectors/tree/main/_template_connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/_template_connector)).
 
 It contains some ideas about structuring your code. Review it to get a general understanding of our example format.

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/fivetran/fivetran-csdk-connectors/stargazers" target="_blank"><img src="https://img.shields.io/github/stars/fivetran/fivetran-csdk-connectors?style=social&label=Star"></a>
-  <a href="https://github.com/fivetran/fivetran-csdk-connectors/blob/main/LICENSE" target="_blank"><img src="https://img.shields.io/badge/License-MIT-blue" alt="License"></a>
-  <a href="https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md" target="_blank"><img src="https://img.shields.io/badge/Managed-Yes-green/" alt="Managed"></a>
+  <a href="https://github.com/fivetran/fivetran_csdk_connectors/stargazers" target="_blank"><img src="https://img.shields.io/github/stars/fivetran/fivetran_csdk_connectors?style=social&label=Star"></a>
+  <a href="https://github.com/fivetran/fivetran_csdk_connectors/blob/main/LICENSE" target="_blank"><img src="https://img.shields.io/badge/License-MIT-blue" alt="License"></a>
+  <a href="https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md" target="_blank"><img src="https://img.shields.io/badge/Managed-Yes-green/" alt="Managed"></a>
 </p>
 
 # Fivetran Connector SDK - Connector Catalog
@@ -56,127 +56,127 @@ These are ready-to-use connectors, requiring minimal modifications to get starte
 
 ### Databases
 
-- **[apache_hbase](apache_hbase)** - Connect and sync data from Apache HBase using happybase and thrift libraries
-- **[apache_hive/using_pyhive](apache_hive/using_pyhive)** - Sync data from Apache Hive using PyHive
-- **[apache_hive/using_sqlalchemy](apache_hive/using_sqlalchemy)** - Sync data from Apache Hive using SQLAlchemy with PyHive
-- **[arango_db](arango_db)** - Sync document and edge collections from ArangoDB multi-model database
-- **[cassandra](cassandra)** - Connect and sync data from Cassandra database
-- **[clickhouse](clickhouse)** - Sync data from ClickHouse database
-- **[couchbase_capella](couchbase_capella)** - Sync data from Couchbase Capella
-- **[couchbase_magma](couchbase_magma)** - Sync data from self-managed Couchbase Server using Magma storage
-- **[dgraph](dgraph)** - Sync e-commerce product catalog from Dgraph graph databases
-- **[documentdb](documentdb)** - Connect to AWS DocumentDB and sync collections (Hybrid Deployment compatible)
-- **[dolphin_db](dolphin_db)** - Sync data from DolphinDB database
-- **[dragonfly_db](dragonfly_db)** - Sync high-performance in-memory data from DragonflyDB
-- **[firebird_db](firebird_db)** - Sync data from Firebird DB
-- **[greenplum_db](greenplum_db)** - Sync data from Greenplum database
-- **[ibm_db2](ibm_db2)** - Connect and sync data from IBM Db2 using ibm_db library
-- **[ibm_informix_using_ibm_db](ibm_informix_using_ibm_db)** - Connect and sync data from IBM Informix
-- **[influx_db](influx_db)** - Sync time-series data from InfluxDB
-- **[neo4j](neo4j)** - Extract data from Neo4j graph databases
-- **[quest_db](quest_db)** - Sync high-performance time series data from QuestDB
-- **[raven_db](raven_db)** - Sync document data from RavenDB NoSQL database
-- **[redis](redis)** - Sync gaming leaderboards and player statistics from Redis
-- **[rethink_db](rethink_db)** - Sync data from RethinkDB real-time database
-- **[sap_hana_sql](sap_hana_sql)** - Connect to SAP HANA SQL Server using hdbcli
-- **[sql_server](sql_server)** - Connect to SQL Server using pyodbc
-- **[teradata](teradata)** - Sync data from Teradata Vantage database
-- **[tidb](tidb)** - Incremental replication from TiDB databases
-- **[timescale_db](timescale_db)** - Sync time-series and vector data from TimescaleDB
-- **[yugabyte_db](yugabyte_db)** - Sync data from YugabyteDB distributed SQL database
+- **[apache_hbase](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/apache_hbase)** - Connect and sync data from Apache HBase using happybase and thrift libraries
+- **[apache_hive/using_pyhive](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/apache_hive/using_pyhive)** - Sync data from Apache Hive using PyHive
+- **[apache_hive/using_sqlalchemy](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/apache_hive/using_sqlalchemy)** - Sync data from Apache Hive using SQLAlchemy with PyHive
+- **[arango_db](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/arango_db)** - Sync document and edge collections from ArangoDB multi-model database
+- **[cassandra](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/cassandra)** - Connect and sync data from Cassandra database
+- **[clickhouse](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/clickhouse)** - Sync data from ClickHouse database
+- **[couchbase_capella](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/couchbase_capella)** - Sync data from Couchbase Capella
+- **[couchbase_magma](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/couchbase_magma)** - Sync data from self-managed Couchbase Server using Magma storage
+- **[dgraph](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/dgraph)** - Sync e-commerce product catalog from Dgraph graph databases
+- **[documentdb](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/documentdb)** - Connect to AWS DocumentDB and sync collections (Hybrid Deployment compatible)
+- **[dolphin_db](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/dolphin_db)** - Sync data from DolphinDB database
+- **[dragonfly_db](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/dragonfly_db)** - Sync high-performance in-memory data from DragonflyDB
+- **[firebird_db](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/firebird_db)** - Sync data from Firebird DB
+- **[greenplum_db](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/greenplum_db)** - Sync data from Greenplum database
+- **[ibm_db2](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/ibm_db2)** - Connect and sync data from IBM Db2 using ibm_db library
+- **[ibm_informix_using_ibm_db](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/ibm_informix_using_ibm_db)** - Connect and sync data from IBM Informix
+- **[influx_db](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/influx_db)** - Sync time-series data from InfluxDB
+- **[neo4j](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/neo4j)** - Extract data from Neo4j graph databases
+- **[quest_db](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/quest_db)** - Sync high-performance time series data from QuestDB
+- **[raven_db](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/raven_db)** - Sync document data from RavenDB NoSQL database
+- **[redis](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/redis)** - Sync gaming leaderboards and player statistics from Redis
+- **[rethink_db](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/rethink_db)** - Sync data from RethinkDB real-time database
+- **[sap_hana_sql](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/sap_hana_sql)** - Connect to SAP HANA SQL Server using hdbcli
+- **[sql_server](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/sql_server)** - Connect to SQL Server using pyodbc
+- **[teradata](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/teradata)** - Sync data from Teradata Vantage database
+- **[tidb](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/tidb)** - Incremental replication from TiDB databases
+- **[timescale_db](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/timescale_db)** - Sync time-series and vector data from TimescaleDB
+- **[yugabyte_db](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/yugabyte_db)** - Sync data from YugabyteDB distributed SQL database
 
 ### Cloud Data Warehouses
 
-- **[aws_athena/using_boto3](aws_athena/using_boto3)** - Sync data from AWS Athena using Boto3
-- **[aws_athena/using_sqlalchemy](aws_athena/using_sqlalchemy)** - Sync data from AWS Athena using SQLAlchemy with PyAthena
-- **[aws_dynamo_db_authentication](aws_dynamo_db_authentication)** - Connect and sync data from AWS DynamoDB
-- **[aws_rds_oracle](aws_rds_oracle)** - Connect and sync data from AWS Oracle
-- **[redshift/simple_redshift_connector](redshift/simple_redshift_connector)** - Sync records from Redshift
-- **[redshift/large_data_volume](redshift/large_data_volume)** - Sync large data volumes from Redshift
-- **[redshift/using_unload](redshift/using_unload)** - Sync data from Redshift using UNLOAD to S3
+- **[aws_athena/using_boto3](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/aws_athena/using_boto3)** - Sync data from AWS Athena using Boto3
+- **[aws_athena/using_sqlalchemy](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/aws_athena/using_sqlalchemy)** - Sync data from AWS Athena using SQLAlchemy with PyAthena
+- **[aws_dynamo_db_authentication](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/aws_dynamo_db_authentication)** - Connect and sync data from AWS DynamoDB
+- **[aws_rds_oracle](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/aws_rds_oracle)** - Connect and sync data from AWS Oracle
+- **[redshift/simple_redshift_connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/redshift/simple_redshift_connector)** - Sync records from Redshift
+- **[redshift/large_data_volume](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/redshift/large_data_volume)** - Sync large data volumes from Redshift
+- **[redshift/using_unload](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/redshift/using_unload)** - Sync data from Redshift using UNLOAD to S3
 
 ### Message Queues & Streaming
 
-- **[apache_pulsar](apache_pulsar)** - Fetch data from Apache Pulsar topics with Reader API
-- **[gcp_pub_sub](gcp_pub_sub)** - Sync data from Google Cloud Pub/Sub
-- **[rabbitmq](rabbitmq)** - Sync messages from RabbitMQ queues
-- **[solace](solace)** - Sync messages from Solace queue
+- **[apache_pulsar](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/apache_pulsar)** - Fetch data from Apache Pulsar topics with Reader API
+- **[gcp_pub_sub](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/gcp_pub_sub)** - Sync data from Google Cloud Pub/Sub
+- **[rabbitmq](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/rabbitmq)** - Sync messages from RabbitMQ queues
+- **[solace](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/solace)** - Sync messages from Solace queue
 
 ### SaaS & APIs
 
-- **[awardco](awardco)** - Sync data from Awardco rewards platform
-- **[betterstack](betterstack)** - Sync uptime monitoring data from Better Stack
-- **[checkly](checkly)** - Sync monitoring check data and analytics from Checkly
-- **[clerk](clerk)** - Sync user data from Clerk authentication
-- **[commonpaper](commonpaper)** - Sync agreement data from Common Paper
-- **[courier](courier)** - Sync notifications data from Courier multi-channel platform
-- **[customer_thermometer](customer_thermometer)** - Sync customer feedback from Customer Thermometer
-- **[data_camp](data_camp)** - Sync course catalog from DataCamp LMS
-- **[discord](discord)** - Sync data from Discord
-- **[docusign](docusign)** - Sync data from Docusign eSignature API
-- **[elastic_email](elastic_email)** - Sync email marketing data from Elastic Email
-- **[fleetio](fleetio)** - Sync fleet management data from Fleetio
-- **[fred](fred)** - Sync economic data from Federal Reserve Economic Data (FRED)
-- **[github](github)** - Sync repository data, commits, and pull requests from GitHub
-- **[github_traffic](github_traffic)** - Sync GitHub repository traffic data
-- **[gnews](gnews)** - Sync news articles from GNews API
-- **[google_trends](google_trends)** - Sync search interest data from Google Trends
-- **[goshippo](goshippo)** - Sync shipment data from Goshippo API
-- **[grey_hr](grey_hr)** - Sync HR data from greytHR API
-- **[gumroad](gumroad)** - Sync sales, products, and subscribers from Gumroad
-- **[harness_io](harness_io)** - Connect and sync data from Harness.io
-- **[healthchecks](healthchecks)** - Sync health check monitoring from Healthchecks.io
-- **[hubspot](hubspot)** - Sync event data from HubSpot
-- **[iterate](iterate)** - Sync NPS survey data from Iterate REST API
-- **[keycloak](keycloak)** - Sync IAM data from Keycloak Admin API
-- **[leavedates](leavedates)** - Sync leave report data from LeaveDates API
-- **[mailerlite](mailerlite)** - Sync email marketing data from MailerLite
-- **[mastertax](mastertax)** - Sync data from MasterTax API
-- **[meilisearch](meilisearch)** - Sync index metadata and documents from MeiliSearch
-- **[microsoft_excel](microsoft_excel)** - Sync data from Microsoft Excel files
-- **[microsoft_intune](microsoft_intune)** - Retrieve managed devices from Microsoft Intune
-- **[n8n](n8n)** - Sync workflow automation data from n8n
-- **[netlify](netlify)** - Sync sites, deploys, and forms from Netlify API
-- **[newsapi](newsapi)** - Sync news articles from NewsAPI
-- **[noaa](noaa)** - Sync weather observations from National Weather Service
-- **[npi_registry](npi_registry)** - Sync healthcare provider data from NPPES NPI Registry
-- **[oauth2_and_accelo_api_connector_multithreading_enabled](oauth2_and_accelo_api_connector_multithreading_enabled)** - Sync data from Accelo API with OAuth 2.0 and multithreading
-- **[odata_api](odata_api)** - Sync data from OData APIs (versions 2 and 4)
-- **[oktopost](oktopost)** - Sync social media exports from Oktopost BI API
-- **[owasp_api_vulns](owasp_api_vulns)** - Sync OWASP API vulnerability data from NVD 2.0
-- **[partech](partech)** - Sync POS data from Partech (formerly Punchh)
-- **[pindrop](pindrop)** - Sync nightly report data from Pindrop
-- **[prefect](prefect)** - Sync workflow orchestration data from Prefect Cloud
-- **[prometheus](prometheus)** - Sync metrics and time series from Prometheus
-- **[resend](resend)** - Sync email data from Resend API
-- **[s3_csv_validation](s3_csv_validation)** - Read and validate CSV files from Amazon S3
-- **[sam_gov](sam_gov)** - Sync government contracting opportunities from SAM.gov
-- **[sap_ariba](sap_ariba)** - Sync procurement data from SAP Ariba
-- **[sendcloud](sendcloud)** - Sync shipment data from Sendcloud API
-- **[sensor_tower](sensor_tower)** - Sync mobile app market intelligence from Sensor Tower
-- **[sensource](sensource)** - Sync traffic and occupancy metrics from SenSource
-- **[similarweb](similarweb)** - Sync website performance metrics from SimilarWeb
-- **[smartsheets](smartsheets)** - Sync sheets and reports from Smartsheets
-- **[snipeitapp](snipeitapp)** - Sync IT asset management data from Snipe-IT
-- **[status_cake](status_cake)** - Sync uptime monitoring from StatusCake
-- **[suitedash](suitedash)** - Sync CRM data from SuiteDash API
-- **[supabase](supabase)** - Sync employee data from Supabase database
-- **[talon_one](talon_one)** - Sync events data from Talon.One
-- **[toast](toast)** - Sync POS data from Toast
-- **[tulip_interfaces](tulip_interfaces)** - Sync data from Tulip Tables
-- **[veeva_vault/basic_auth](veeva_vault/basic_auth)** - Authenticate to Veeva Vault with basic auth
-- **[veeva_vault/session_id_auth](veeva_vault/session_id_auth)** - Authenticate to Veeva Vault with session ID
-- **[vercel](vercel)** - Sync deployment data from Vercel REST API
-- **[zigpoll](zigpoll)** - Sync polling data from Zigpoll
+- **[awardco](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/awardco)** - Sync data from Awardco rewards platform
+- **[betterstack](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/betterstack)** - Sync uptime monitoring data from Better Stack
+- **[checkly](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/checkly)** - Sync monitoring check data and analytics from Checkly
+- **[clerk](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/clerk)** - Sync user data from Clerk authentication
+- **[commonpaper](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/commonpaper)** - Sync agreement data from Common Paper
+- **[courier](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/courier)** - Sync notifications data from Courier multi-channel platform
+- **[customer_thermometer](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/customer_thermometer)** - Sync customer feedback from Customer Thermometer
+- **[data_camp](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/data_camp)** - Sync course catalog from DataCamp LMS
+- **[discord](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/discord)** - Sync data from Discord
+- **[docusign](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/docusign)** - Sync data from Docusign eSignature API
+- **[elastic_email](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/elastic_email)** - Sync email marketing data from Elastic Email
+- **[fleetio](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/fleetio)** - Sync fleet management data from Fleetio
+- **[fred](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/fred)** - Sync economic data from Federal Reserve Economic Data (FRED)
+- **[github](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/github)** - Sync repository data, commits, and pull requests from GitHub
+- **[github_traffic](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/github_traffic)** - Sync GitHub repository traffic data
+- **[gnews](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/gnews)** - Sync news articles from GNews API
+- **[google_trends](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/google_trends)** - Sync search interest data from Google Trends
+- **[goshippo](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/goshippo)** - Sync shipment data from Goshippo API
+- **[grey_hr](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/grey_hr)** - Sync HR data from greytHR API
+- **[gumroad](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/gumroad)** - Sync sales, products, and subscribers from Gumroad
+- **[harness_io](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/harness_io)** - Connect and sync data from Harness.io
+- **[healthchecks](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/healthchecks)** - Sync health check monitoring from Healthchecks.io
+- **[hubspot](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/hubspot)** - Sync event data from HubSpot
+- **[iterate](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/iterate)** - Sync NPS survey data from Iterate REST API
+- **[keycloak](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/keycloak)** - Sync IAM data from Keycloak Admin API
+- **[leavedates](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/leavedates)** - Sync leave report data from LeaveDates API
+- **[mailerlite](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/mailerlite)** - Sync email marketing data from MailerLite
+- **[mastertax](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/mastertax)** - Sync data from MasterTax API
+- **[meilisearch](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/meilisearch)** - Sync index metadata and documents from MeiliSearch
+- **[microsoft_excel](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/microsoft_excel)** - Sync data from Microsoft Excel files
+- **[microsoft_intune](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/microsoft_intune)** - Retrieve managed devices from Microsoft Intune
+- **[n8n](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/n8n)** - Sync workflow automation data from n8n
+- **[netlify](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/netlify)** - Sync sites, deploys, and forms from Netlify API
+- **[newsapi](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/newsapi)** - Sync news articles from NewsAPI
+- **[noaa](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/noaa)** - Sync weather observations from National Weather Service
+- **[npi_registry](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/npi_registry)** - Sync healthcare provider data from NPPES NPI Registry
+- **[oauth2_and_accelo_api_connector_multithreading_enabled](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/oauth2_and_accelo_api_connector_multithreading_enabled)** - Sync data from Accelo API with OAuth 2.0 and multithreading
+- **[odata_api](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/odata_api)** - Sync data from OData APIs (versions 2 and 4)
+- **[oktopost](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/oktopost)** - Sync social media exports from Oktopost BI API
+- **[owasp_api_vulns](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/owasp_api_vulns)** - Sync OWASP API vulnerability data from NVD 2.0
+- **[partech](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/partech)** - Sync POS data from Partech (formerly Punchh)
+- **[pindrop](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/pindrop)** - Sync nightly report data from Pindrop
+- **[prefect](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/prefect)** - Sync workflow orchestration data from Prefect Cloud
+- **[prometheus](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/prometheus)** - Sync metrics and time series from Prometheus
+- **[resend](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/resend)** - Sync email data from Resend API
+- **[s3_csv_validation](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/s3_csv_validation)** - Read and validate CSV files from Amazon S3
+- **[sam_gov](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/sam_gov)** - Sync government contracting opportunities from SAM.gov
+- **[sap_ariba](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/sap_ariba)** - Sync procurement data from SAP Ariba
+- **[sendcloud](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/sendcloud)** - Sync shipment data from Sendcloud API
+- **[sensor_tower](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/sensor_tower)** - Sync mobile app market intelligence from Sensor Tower
+- **[sensource](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/sensource)** - Sync traffic and occupancy metrics from SenSource
+- **[similarweb](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/similarweb)** - Sync website performance metrics from SimilarWeb
+- **[smartsheets](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/smartsheets)** - Sync sheets and reports from Smartsheets
+- **[snipeitapp](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/snipeitapp)** - Sync IT asset management data from Snipe-IT
+- **[status_cake](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/status_cake)** - Sync uptime monitoring from StatusCake
+- **[suitedash](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/suitedash)** - Sync CRM data from SuiteDash API
+- **[supabase](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/supabase)** - Sync employee data from Supabase database
+- **[talon_one](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/talon_one)** - Sync events data from Talon.One
+- **[toast](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/toast)** - Sync POS data from Toast
+- **[tulip_interfaces](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/tulip_interfaces)** - Sync data from Tulip Tables
+- **[veeva_vault/basic_auth](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/veeva_vault/basic_auth)** - Authenticate to Veeva Vault with basic auth
+- **[veeva_vault/session_id_auth](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/veeva_vault/session_id_auth)** - Authenticate to Veeva Vault with session ID
+- **[vercel](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/vercel)** - Sync deployment data from Vercel REST API
+- **[zigpoll](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/zigpoll)** - Sync polling data from Zigpoll
 
 </details>
 
 ## Documentation & Resources
 
-- **[_template_connector](_template_connector)** - Reference template for building new connectors
-- **[CONTRIBUTING.md](CONTRIBUTING.md)** - Guide for contributing to this repository
-- **[PYTHON_CODING_STANDARDS.md](PYTHON_CODING_STANDARDS.md)** - Python coding standards and best practices
-- **[FIVETRAN_CODING_PRINCIPLES.md](FIVETRAN_CODING_PRINCIPLES.md)** - Code review principles and PR guidelines
+- **[_template_connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/_template_connector)** - Reference template for building new connectors
+- **[CONTRIBUTING.md](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/CONTRIBUTING.md)** - Guide for contributing to this repository
+- **[PYTHON_CODING_STANDARDS.md](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/PYTHON_CODING_STANDARDS.md)** - Python coding standards and best practices
+- **[FIVETRAN_CODING_PRINCIPLES.md](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/FIVETRAN_CODING_PRINCIPLES.md)** - Code review principles and PR guidelines
 - **[Connector SDK Documentation](https://fivetran.com/docs/connectors/connector-sdk)** - Official SDK documentation
 - **[Connector SDK Best Practices](https://fivetran.com/docs/connector-sdk/best-practices)** - Best practices guide
 
@@ -184,7 +184,7 @@ These are ready-to-use connectors, requiring minimal modifications to get starte
 
 We welcome contributions from the community! Whether you want to add a new connector, improve existing ones, or fix bugs, your contributions are appreciated.
 
-Please read our [CONTRIBUTING.md](CONTRIBUTING.md) guide for detailed information on:
+Please read our [CONTRIBUTING.md](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/CONTRIBUTING.md) guide for detailed information on:
 - How to fork and create a pull request
 - Coding standards and guidelines
 - Testing requirements
@@ -192,7 +192,7 @@ Please read our [CONTRIBUTING.md](CONTRIBUTING.md) guide for detailed informatio
 
 ## Issue
 
-Found an issue? Submit an [issue](https://github.com/fivetran/fivetran-csdk-connectors/issues) and get connected to a Fivetran developer.
+Found an issue? Submit an [issue](https://github.com/fivetran/fivetran_csdk_connectors/issues) and get connected to a Fivetran developer.
 
 ## Support
 
@@ -210,8 +210,8 @@ As with other new connectors, SDK connectors have a [14-day trial period](https:
 
 ## Maintenance
 
-The `fivetran-csdk-connectors` repository is actively maintained by Fivetran Developers. Reach out to our [Support team](https://support.fivetran.com/hc/en-us) for any inquiries.
+The `fivetran_csdk_connectors` repository is actively maintained by Fivetran Developers. Reach out to our [Support team](https://support.fivetran.com/hc/en-us) for any inquiries.
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License - see the [LICENSE](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/LICENSE) file for details.

--- a/_template_connector/README_template.md
+++ b/_template_connector/README_template.md
@@ -41,7 +41,7 @@ This example was contributed by [Contributor Name/Organization](link-to-profile-
 
 
 ## Requirements
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)   
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)   
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -78,7 +78,7 @@ fivetran init --template <connector-name>
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 
 ## Requirements file

--- a/apache_hbase/README.md
+++ b/apache_hbase/README.md
@@ -6,7 +6,7 @@ This connector shows how to sync data from Apache HBase databases using Fivetran
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -47,7 +47,7 @@ The connector requires the following configuration parameters:
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/apache_hive/using_pyhive/README.md
+++ b/apache_hive/using_pyhive/README.md
@@ -6,7 +6,7 @@ This connector shows how to fetch data from Apache Hive using the `PyHive` and `
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -46,7 +46,7 @@ This connector requires the following configuration parameters to establish a co
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/apache_hive/using_sqlalchemy/README.md
+++ b/apache_hive/using_sqlalchemy/README.md
@@ -6,7 +6,7 @@ This connector demonstrates how to fetch data from Apache Hive using `SQLAlchemy
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -45,7 +45,7 @@ This connector requires the following configuration parameters to establish a co
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/apache_pulsar/README.md
+++ b/apache_pulsar/README.md
@@ -8,7 +8,7 @@ The connector is designed for organizations using Apache Pulsar who need to sync
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -58,7 +58,7 @@ Configuration parameters:
 - `topics` (required) - Comma-separated list of topic names to sync.
 - `auth_token` (optional) - Optional authentication token for secured Pulsar clusters.
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/arango_db/README.md
+++ b/arango_db/README.md
@@ -8,7 +8,7 @@ The connector syncs three collections from a travel dataset: airports (document 
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -56,7 +56,7 @@ Configuration parameters:
 - `username` (required): Your ArangoDB username.
 - `password` (required): Your ArangoDB password.
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/awardco/README.md
+++ b/awardco/README.md
@@ -12,7 +12,7 @@ This example connector uses the Fivetran Connector SDK to sync Awardco user data
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -62,7 +62,7 @@ Configuration parameters:
 - Validation — `awardco-users-connector/connector.py:70-81`
 - Main config usage in update — `awardco-users-connector/connector.py:198-199`
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/aws_athena/using_boto3/README.md
+++ b/aws_athena/using_boto3/README.md
@@ -13,7 +13,7 @@ This pattern is ideal for:
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -56,7 +56,7 @@ The connector requires the following configuration parameters:
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/aws_athena/using_sqlalchemy/README.md
+++ b/aws_athena/using_sqlalchemy/README.md
@@ -13,7 +13,7 @@ This pattern is helpful when:
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -54,7 +54,7 @@ The connector requires the following configuration parameters:
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/aws_dynamo_db_authentication/README.md
+++ b/aws_dynamo_db_authentication/README.md
@@ -14,7 +14,7 @@ Refer to [Boto3 DynamoDB Docs](https://boto3.amazonaws.com/v1/documentation/api/
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -56,7 +56,7 @@ The connector requires the following configuration parameters:
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/aws_rds_oracle/README.md
+++ b/aws_rds_oracle/README.md
@@ -6,7 +6,7 @@ This connector demonstrates how to sync records from an AWS RDS Oracle database 
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -47,7 +47,7 @@ The connector requires the following configuration parameters in `configuration.
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/betterstack/README.md
+++ b/betterstack/README.md
@@ -6,7 +6,7 @@ This connector syncs uptime monitoring data from Better Stack's Uptime API. It r
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -45,7 +45,7 @@ The connector requires the following configuration parameter:
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/cassandra/README.md
+++ b/cassandra/README.md
@@ -8,7 +8,7 @@ The connector is designed to handle large datasets efficiently through streaming
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -57,7 +57,7 @@ The connector requires the following configuration parameters:
 - keyspace: The Cassandra keyspace to connect to
 - port: The port number for the Cassandra server
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/checkly/README.md
+++ b/checkly/README.md
@@ -8,7 +8,7 @@ The connector implements Bearer token authentication, handles pagination automat
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -61,7 +61,7 @@ Optional parameters:
 - `quick_range`: Time range for analytics data collection (default: `last24Hours`)
   - Available options: `last24Hours`, `last7Days`, `last30Days`, `thisWeek`, `thisMonth`, `lastWeek`, `lastMonth`
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/clerk/README.md
+++ b/clerk/README.md
@@ -8,7 +8,7 @@ Clerk is a user authentication and management platform that provides APIs for ma
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -52,7 +52,7 @@ The configuration file contains the API key required to authenticate with the Cl
 Configuration parameters:
 - `api_key` (required): Your Clerk API secret key.
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/clickhouse/README.md
+++ b/clickhouse/README.md
@@ -6,7 +6,7 @@ This connector shows how to pull data from ClickHouse databases. It connects to 
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -51,7 +51,7 @@ The connector requires the following configuration parameters:
 - password: Password for authentication
 - database: The ClickHouse database to connect to
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/commonpaper/README.md
+++ b/commonpaper/README.md
@@ -10,7 +10,7 @@ This connector fetches and syncs agreement data from the Common Paper API. It pr
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -53,7 +53,7 @@ Configuration parameters:
 - `api_key`: Your Common Paper API key
 - `initial_sync_timestamp`: ISO format timestamp for the initial sync (optional, defaults to current time)
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/couchbase_capella/README.md
+++ b/couchbase_capella/README.md
@@ -5,11 +5,11 @@
 This connector example demonstrates how to sync data from Couchbase Capella using the Connector SDK. It connects to a Couchbase Capella instance, executes SQL++ (N1QL) queries to fetch data from a specific bucket, scope, and collection, and efficiently streams the data to destination table while implementing best practices for handling large datasets.
 This connector is built for Couchbase Capella. It supports buckets using either the Magma or Couchstore storage engines.
 
-> For syncing data from a Magma bucket on self-managed Couchbase Server, please refer to the [Couchbase Magma connector example](https://github.com/fivetran/fivetran-csdk-connectors/tree/main/couchbase_magma)
+> For syncing data from a Magma bucket on self-managed Couchbase Server, please refer to the [Couchbase Magma connector example](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/couchbase_magma)
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -52,7 +52,7 @@ The connector requires the following configuration parameters to connect to your
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/couchbase_magma/README.md
+++ b/couchbase_magma/README.md
@@ -5,11 +5,11 @@
 This connector example demonstrates how to sync data from a self-managed Couchbase Server (local, on-premises, or self-hosted in the cloud) using the Magma storage engine with the Connector SDK.
 It connects to a Couchbase instance, runs SQL++ (N1QL) queries to retrieve data from a specified Magma bucket, scope, and collection, and streams the results efficiently to a destination table—following best practices for handling large datasets.
 
-> For syncing data from a Magma bucket on Couchbase Capella, please refer to the [Couchbase Capella connector example](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/examples/source_examples/couchbase_capella).
+> For syncing data from a Magma bucket on Couchbase Capella, please refer to the [Couchbase Capella connector example](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/examples/source_examples/couchbase_capella).
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -53,7 +53,7 @@ The connector requires the following configuration parameters to connect to your
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/courier/README.md
+++ b/courier/README.md
@@ -6,7 +6,7 @@ This connector fetches data from the Courier API, a multi-channel notification p
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -48,7 +48,7 @@ The connector requires the following configuration parameters:
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/customer_thermometer/README.md
+++ b/customer_thermometer/README.md
@@ -8,7 +8,7 @@ The connector implements API key authentication, parses XML responses, and is st
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -54,7 +54,7 @@ The connector requires API key authentication for the Customer Thermometer API. 
 - `api_key`: (Required) Your Customer Thermometer API key
 - `from_date`: (Optional) Start date for initial data retrieval in YYYY-MM-DD format. If not provided, incremental sync will start from EPOCH (1970-01-01) for the initial sync, then use state-based incremental sync for subsequent runs.
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/data_camp/README.md
+++ b/data_camp/README.md
@@ -8,7 +8,7 @@ The connector implements bearer token authentication with comprehensive retry lo
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -60,7 +60,7 @@ The connector requires bearer token authentication for the DataCamp LMS Catalog 
   - Leave blank to use the default DataCamp production server: `https://lms-catalog-api.datacamp.com`
   - You can specify a URL for testing or mock environments.
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/dgraph/README.md
+++ b/dgraph/README.md
@@ -12,7 +12,7 @@ The connector showcases best practices for syncing graph data:
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -59,7 +59,7 @@ Configuration parameters:
 - `dgraph_url` (required) - The base URL of your Dgraph instance (e.g., `http://localhost:8080` or `https://your-instance.dgraph.io`). Must start with `http://` or `https://`.
 - `api_key` (required) - Authentication token for accessing the Dgraph API.
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/discord/README.md
+++ b/discord/README.md
@@ -15,7 +15,7 @@ This connector is particularly well-suited for the following AI/ML use cases:
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -67,7 +67,7 @@ The connector requires the following configuration parameters in `configuration.
 - `sync_messages` (optional): Specifies whether to sync message data (default: `true`)
 - `message_limit` (optional): Maximum messages per channel to sync (default: `1000`)
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/documentdb/README.md
+++ b/documentdb/README.md
@@ -12,7 +12,7 @@ The connector is designed to handle large datasets efficiently through streaming
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -62,7 +62,7 @@ The connector requires the following configuration parameters:
 - database: The DocumentDB database name to connect to
 - port: The port number for the DocumentDB cluster (default: 27017)
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/docusign/README.md
+++ b/docusign/README.md
@@ -10,7 +10,7 @@ This example was contributed by [Arpit Kumar Khatri](https://github.com/ArpitKha
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -54,7 +54,7 @@ Configuration parameters:
 - base_url (required) - The base URL for the Docusign API (e.g., `https://demo.docusign.net/restapi` for demo or `https://na3.docusign.net/restapi` for production).
 - account_id (required) - The Account ID for your Docusign account.
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/dolphin_db/README.md
+++ b/dolphin_db/README.md
@@ -6,7 +6,7 @@ This connector syncs data from DolphinDB, a high-performance time series columna
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -48,7 +48,7 @@ The connector requires the following configuration parameters for connecting to 
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/dragonfly_db/README.md
+++ b/dragonfly_db/README.md
@@ -8,7 +8,7 @@ The connector is particularly valuable for organizations using DragonflyDB as a 
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -80,7 +80,7 @@ Key pattern examples:
 - `user:*:profile` - All user profile keys
 - `rate_limit:*` - All rate limiter keys
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 
@@ -94,7 +94,7 @@ redis
 
 ## Authentication
 
-The connector supports flexible authentication options compatible with DragonflyDB deployments (refer to the `build_connection_params` function in [connector.py](connector.py)).
+The connector supports flexible authentication options compatible with DragonflyDB deployments (refer to the `build_connection_params` function in [connector.py](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/dragonfly_db/connector.py)).
 
 Basic configuration without authentication:
 ```json
@@ -137,7 +137,7 @@ SSL/TLS configuration:
 
 ## Pagination
 
-The connector implements the `SCAN` command for efficient, non-blocking key iteration (refer to the `scan_keys` function in [connector.py](connector.py)):
+The connector implements the `SCAN` command for efficient, non-blocking key iteration (refer to the `scan_keys` function in [connector.py](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/dragonfly_db/connector.py)):
 
 - Uses cursor-based iteration starting from cursor position 0
 - Processes keys in configurable batches (default: 100 keys per `SCAN` operation)
@@ -150,7 +150,7 @@ The `SCAN` operation is memory-efficient, non-blocking, and allows other Dragonf
 
 ## Data handling
 
-The connector performs comprehensive data extraction and transformation (refer to the following functions in [connector.py](connector.py)):
+The connector performs comprehensive data extraction and transformation (refer to the following functions in [connector.py](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/dragonfly_db/connector.py)):
 
 - `get_key_info` - Retrieves comprehensive information about a key
 - `extract_value_by_type` - Handles type-specific value extraction
@@ -172,7 +172,7 @@ Data handling workflow:
 
 ## Error handling
 
-The connector implements comprehensive error handling strategies (refer to the following functions in [connector.py](connector.py)):
+The connector implements comprehensive error handling strategies (refer to the following functions in [connector.py](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/dragonfly_db/connector.py)):
 
 - Connection validation with retry logic (`create_dragonfly_client` function) - Tests DragonflyDB connectivity during client creation with ping operation, implements exponential backoff retry logic for transient failures (max 3 attempts), handles SSL configuration errors, raises RuntimeError on failure.
 - Configuration validation (`validate_configuration` function) - Ensures required parameters (host, port) are present, raises ValueError for missing configuration.

--- a/elastic_email/README.md
+++ b/elastic_email/README.md
@@ -6,7 +6,7 @@ This connector syncs email marketing data from Elastic Email to your destination
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -48,7 +48,7 @@ The connector requires the following configuration parameters:
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 
@@ -68,11 +68,11 @@ To set up authentication:
 4. Make a note of the API key value.
 5. Add the API key to your `configuration.json` file as the value for `api_key`.
 
-The connector validates that the API key is present during initialization. Refer to the `validate_configuration` function in [connector.py](connector.py).
+The connector validates that the API key is present during initialization. Refer to the `validate_configuration` function in [connector.py](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/elastic_email/connector.py).
 
 ## Pagination
 
-The connector handles pagination using offset-based pagination for all API endpoints. Each endpoint supports `limit` and `offset` parameters to retrieve data in batches. The connector uses a page limit of 100 records per request and automatically increments the offset until all data is retrieved. Refer to the `process_paginated_endpoint` function in [connector.py](connector.py).
+The connector handles pagination using offset-based pagination for all API endpoints. Each endpoint supports `limit` and `offset` parameters to retrieve data in batches. The connector uses a page limit of 100 records per request and automatically increments the offset until all data is retrieved. Refer to the `process_paginated_endpoint` function in [connector.py](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/elastic_email/connector.py).
 
 ## Data handling
 
@@ -84,7 +84,7 @@ The connector processes data from the Elastic Email API and transforms it for th
 - Incremental sync is supported for events using date-based filtering
 - Data is processed in batches to avoid loading large datasets into memory
 
-Refer to the `flatten_dict` and `process_paginated_endpoint` functions in [connector.py](connector.py).
+Refer to the `flatten_dict` and `process_paginated_endpoint` functions in [connector.py](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/elastic_email/connector.py).
 
 ## Error handling
 
@@ -96,7 +96,7 @@ The connector implements comprehensive error handling:
 - All errors are logged using the SDK logging framework
 - Failed requests raise RuntimeError with descriptive error messages
 
-Refer to the `make_request_with_retry` function in [connector.py](connector.py).
+Refer to the `make_request_with_retry` function in [connector.py](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/elastic_email/connector.py).
 
 ## Tables created
 
@@ -118,7 +118,7 @@ The connector creates the following tables in the destination:
 | `COMPLAINT` | `email` | Spam complaint email addresses. |
 | `USUBSCRIBE` | `email` | Unsubscribed email addresses. |
 
-All table schemas are defined with primary keys only. Column data types are inferred by Fivetran based on the actual data. Nested objects are flattened with underscore-separated column names. Refer to the `schema` function in [connector.py](connector.py).
+All table schemas are defined with primary keys only. Column data types are inferred by Fivetran based on the actual data. Nested objects are flattened with underscore-separated column names. Refer to the `schema` function in [connector.py](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/elastic_email/connector.py).
 
 ## Additional considerations
 

--- a/firebird_db/README.md
+++ b/firebird_db/README.md
@@ -10,7 +10,7 @@ The connector maintains tables as defined in the `schema.py` file:
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)   
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)   
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -53,7 +53,7 @@ The connector requires configuration with your Firebird database credentials:
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/fleetio/README.md
+++ b/fleetio/README.md
@@ -12,7 +12,7 @@ This example was contributed by [Fleetio](https://www.fleetio.com/).
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -45,7 +45,7 @@ You can generate your Account Token and API Key [here](https://secure.fleetio.co
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/fred/README.md
+++ b/fred/README.md
@@ -6,7 +6,7 @@ This connector syncs economic data from the Federal Reserve Economic Data (FRED)
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -53,7 +53,7 @@ fivetran init --template fred
 - `series_ids`: Comma-separated list of series IDs to sync (e.g., "GNPCA,UNRATE,CPIAUCSL")
 - `sync_start_date`: Optional start date for syncing observations in YYYY-MM-DD format (defaults to 2020-01-01)
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/gcp_pub_sub/README.md
+++ b/gcp_pub_sub/README.md
@@ -8,7 +8,7 @@ This connector demonstrates how to sync data from Google Cloud Pub/Sub to a dest
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -53,7 +53,7 @@ The connector requires the following configuration parameters:
 - `subscription_name` – Name of the Pub/Sub subscription to consume messages from
 - `topic_name` – Name of the Pub/Sub topic associated with the subscription
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/github/README.md
+++ b/github/README.md
@@ -16,7 +16,7 @@ Example use cases include:
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -68,7 +68,7 @@ Configuration parameters:
 - `organization` (required) - GitHub organization name to sync (can be comma-separated for multiple orgs).
 - `installation_id` (required) - Installation ID for the GitHub App on your organization.
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 
@@ -320,7 +320,7 @@ Rate limit errors
 
 ### Related examples
 
-- [github_traffic connector example](../github_traffic/) - This example shows how to sync GitHub repository traffic metrics (views, clones, referrers, and popular content paths) using the GitHub REST API. It demonstrates how to work with GitHub's traffic analytics endpoints, handle limited historical data (14 days), and use Personal Access Token authentication.
+- [github_traffic connector example](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/github_traffic) - This example shows how to sync GitHub repository traffic metrics (views, clones, referrers, and popular content paths) using the GitHub REST API. It demonstrates how to work with GitHub's traffic analytics endpoints, handle limited historical data (14 days), and use Personal Access Token authentication.
 - [Certificate authentication pattern example](https://github.com/fivetran/fivetran_connector_sdk/tree/main/examples/common_patterns_for_connectors/authentication/certificate/) - This example demonstrates certificate-based authentication with two approaches - using base64 encoded certificates in configuration, or retrieving certificates from AWS S3 at runtime. Useful for understanding advanced credential management patterns that can be applied to GitHub App private keys.
 
 ### Additional resources

--- a/github_traffic/README.md
+++ b/github_traffic/README.md
@@ -6,7 +6,7 @@ This connector syncs GitHub repository traffic data using the GitHub REST API. I
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -44,7 +44,7 @@ Update the `configuration.json` file with your GitHub Personal Access Token and 
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/gnews/README.md
+++ b/gnews/README.md
@@ -6,7 +6,7 @@ This example demonstrates how to build a Fivetran Connector SDK integration for 
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -51,7 +51,7 @@ The `configuration.json` file provides the GNews credentials and query parameter
 - `search_term` (required): The query you are looking to get data on
 - `from_date` (required): How far back the historical sync will go
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/google_trends/README.md
+++ b/google_trends/README.md
@@ -8,7 +8,7 @@ The connector creates a single `google_trends` table with detailed interest scor
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -63,7 +63,7 @@ Configuration parameters:
 
 You can also define the search array as a constant in `config.py`. The connector will use these default values if no `searches` key is provided in the `configuration.json`.
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/goshippo/README.md
+++ b/goshippo/README.md
@@ -8,7 +8,7 @@ The connector fetches shipment records along with related data such as shipping 
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -47,7 +47,7 @@ The connector requires the following configuration parameters:
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Authentication
 

--- a/greenplum_db/README.md
+++ b/greenplum_db/README.md
@@ -6,7 +6,7 @@ This connector example demonstrates how to fetch data from a Greenplum database 
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -48,7 +48,7 @@ The connector requires the following configuration parameters to connect to your
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/grey_hr/README.md
+++ b/grey_hr/README.md
@@ -6,7 +6,7 @@ This connector syncs Employee, Leave Transactions, and Attendance Insights data 
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -56,7 +56,7 @@ fivetran init --template grey_hr
 - `greythr_domain` - Your organization's greytHR domain (e.g., moxemo6127dato.greythr.com)
 - `sync_start_date` - The starting date for syncing leave transactions and attendance data in YYYY-MM-DD format (e.g., 2020-01-01). If not provided, defaults to 1900-01-01
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/gumroad/README.md
+++ b/gumroad/README.md
@@ -6,7 +6,7 @@ This connector fetches sales, products, and subscriber data from the Gumroad API
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -46,7 +46,7 @@ The connector requires the following configuration parameter:
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/harness_io/README.md
+++ b/harness_io/README.md
@@ -8,7 +8,7 @@ This connector extracts data from `Harness.io` API and loads it into a destinati
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -51,7 +51,7 @@ The connector requires the following configuration parameters:
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 
 ## Requirements file

--- a/healthchecks/README.md
+++ b/healthchecks/README.md
@@ -10,7 +10,7 @@ The connector retrieves data from four primary endpoints: health checks (monitor
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -50,7 +50,7 @@ The connector requires the following configuration parameter:
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/hubspot/README.md
+++ b/hubspot/README.md
@@ -17,7 +17,7 @@ Refer to [HubSpot's Event Analytics API documentation](https://developers.hubspo
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -56,7 +56,7 @@ The connector requires the following configuration parameters:
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/ibm_db2/README.md
+++ b/ibm_db2/README.md
@@ -6,7 +6,7 @@ This connector allows you to sync data from IBM Db2 to a destination using the F
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -58,7 +58,7 @@ The configuration parameters are:
 - `schema_name`: The schema name in the Db2 database where the table resides
 - `table_name`: The name of the table to sync data from
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/ibm_informix_using_ibm_db/README.md
+++ b/ibm_informix_using_ibm_db/README.md
@@ -8,7 +8,7 @@ This connector uses the native `ibm_db` Python package provided by IBM to connec
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -49,7 +49,7 @@ The connector requires the following configuration parameters:
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/influx_db/README.md
+++ b/influx_db/README.md
@@ -6,7 +6,7 @@ This connector enables data synchronization from InfluxDB using Fivetran Connect
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -47,7 +47,7 @@ The connector requires the following configuration parameters:
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/iterate/README.md
+++ b/iterate/README.md
@@ -6,7 +6,7 @@ This custom Fivetran connector extracts NPS survey data from the [Iterate](https
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -52,7 +52,7 @@ Configuration parameters:
 - `api_token` (required): Your Iterate API access token.
 - `start_date` (optional): UTC datetime in ISO 8601 format with 'Z' suffix (e.g., "2023-01-01T00:00:00Z"). If not provided, sync starts from EPOCH time (1970-01-01T00:00:00Z) to capture all historical data.
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/keycloak/README.md
+++ b/keycloak/README.md
@@ -6,7 +6,7 @@ Keycloak is an open-source identity and access management solution that provides
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -62,7 +62,7 @@ Configuration parameters:
 - `sync_events` - String value "true" or "false" to enable/disable event syncing (default: "true")
 - `start_date` - Start date for incremental event sync in YYYY-MM-DD format (e.g., 2024-01-01). If not specified, defaults to 30 days ago from the current date
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/leavedates/README.md
+++ b/leavedates/README.md
@@ -7,7 +7,7 @@ The [LeaveDates](https://app.leavedates.com/) connector fetches leave report dat
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -59,7 +59,7 @@ Required fields:
 Optional fields:
 - `start_date` - ISO format timestamp for historical data sync (defaults to 1900-01-01 if not provided)
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 
 ## Requirements file

--- a/mailerlite/README.md
+++ b/mailerlite/README.md
@@ -4,7 +4,7 @@
 This connector demonstrates how to fetch email marketing data from [MailerLite](https://www.mailerlite.com/) and upsert it into your destination using the Fivetran Connector SDK. The connector synchronizes the most important entities: subscribers, groups, campaigns, and custom fields from your MailerLite account. It implements pagination handling for large datasets and includes incremental synchronization capabilities using cursor-based and page-based pagination depending on the endpoint.
 
 ## Requirements
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -45,7 +45,7 @@ The configuration keys required for your connector are as follows:
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 The connector uses the `requests` library for HTTP communication, which is pre-installed in the Fivetran environment.

--- a/mastertax/README.md
+++ b/mastertax/README.md
@@ -6,7 +6,7 @@ This connector fetches data extracts from the MasterTax API provided by [ADP](ht
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -47,7 +47,7 @@ The connector reads configuration details from a `configuration.json` file. Requ
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/meilisearch/README.md
+++ b/meilisearch/README.md
@@ -4,7 +4,7 @@
 This connector demonstrates how to fetch index metadata and document data from [MeiliSearch](https://www.meilisearch.com/) and upsert it into your destination using the Fivetran Connector SDK. MeiliSearch is a fast, typo-tolerant search engine API commonly used for powering search functionality in e-commerce platforms, SaaS applications, and content management systems. The connector synchronizes all indexes and their documents from your MeiliSearch instance, enabling analytics on search data, product catalogs, user reviews, and search query performance.
 
 ## Requirements
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -46,7 +46,7 @@ fivetran init --template meilisearch
 - `api_url` (required): The base URL of your MeiliSearch instance (e.g., `https://ms-xxx.meilisearch.io` for MeiliSearch Cloud or `http://localhost:7700` for self-hosted)
 - `api_key` (required): Your MeiliSearch API key for authentication (master key or search API key with read permissions)
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 The connector uses the `requests` library for HTTP communication, which is pre-installed in the Fivetran environment.

--- a/microsoft_excel/README.md
+++ b/microsoft_excel/README.md
@@ -11,7 +11,7 @@ It's designed to efficiently handle Excel files of various sizes, providing flex
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -55,7 +55,7 @@ The connector requires AWS S3 credentials and file information:
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/microsoft_intune/README.md
+++ b/microsoft_intune/README.md
@@ -7,7 +7,7 @@ This example demonstrates how to build a connector for [Microsoft Intune](https:
 ## Requirements
 
 - Microsoft Intune credentials: `tenant_id`, `client_id`, and `client_secret`
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -47,7 +47,7 @@ The connector expects a `configuration.json` file with the following structure:
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Authentication
 

--- a/n8n/README.md
+++ b/n8n/README.md
@@ -6,7 +6,7 @@ This connector syncs workflow automation data from n8n, including workflows and 
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -53,7 +53,7 @@ The connector requires the following configuration parameters:
 - `base_url` (required): The base URL of your n8n instance (e.g., `https://your-n8n-instance.com` for cloud or `http://localhost:5678` for self-hosted)
 - `api_key` (required): Your n8n API key with read permissions for workflows and executions
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/neo4j/README.md
+++ b/neo4j/README.md
@@ -6,7 +6,7 @@ This connector shows how to extract data from Neo4j graph databases and upsert i
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -53,7 +53,7 @@ The connector requires the following configuration parameters:
 - `password`: Neo4j database password
 - `database`: Name of the specific Neo4j database to connect to
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 
 ## Requirements file

--- a/netlify/README.md
+++ b/netlify/README.md
@@ -6,7 +6,7 @@ This connector demonstrates how to fetch data from the Netlify API, including si
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -46,7 +46,7 @@ The connector requires the following configuration parameter:
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/newsapi/README.md
+++ b/newsapi/README.md
@@ -14,7 +14,7 @@ This example uses the [News API's /v2/everything](https://newsapi.org/docs/endpo
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -54,7 +54,7 @@ The connector requires the following configuration parameters:
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/noaa/README.md
+++ b/noaa/README.md
@@ -3,7 +3,7 @@
 ## Connector overview
 This connector retrieves weather observation data and active alerts from the [National Weather Service (NOAA) API](https://www.weather.gov/documentation/services-web-api) and syncs it to Fivetran destinations. The connector fetches current observations from specified weather stations and weather alerts for designated areas, supporting incremental syncing to efficiently process weather data over time.
 ## Requirements
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -64,7 +64,7 @@ Full Configuration (with all optional parameters):
 - `alert_area` (optional): Two-letter US state code for filtering weather alerts (e.g., "IL", "CA"). Default behavior if omitted: fetches all active weather alerts across the United States.
 - `start_date` (optional): Date in YYYY-MM-DD format to start syncing observations from (e.g., "2025-01-01"). Default behavior if omitted: starts syncing from the current time (no historical backfill).
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 This connector uses only the pre-installed packages in the Fivetran environment and does not require any additional dependencies.

--- a/npi_registry/README.md
+++ b/npi_registry/README.md
@@ -6,7 +6,7 @@ This connector fetches healthcare provider data from the National Plan and Provi
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -51,7 +51,7 @@ The `configuration.json` file requires a single parameter: the complete API URL 
 
 - `api_url` (required): Complete API URL generated from the NPPES API demo page. The URL should include your search criteria and the `limit` parameter. The API supports a maximum limit of 200 results per request.
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ### How to generate your API URL
 

--- a/oauth2_and_accelo_api_connector_multithreading_enabled/README.md
+++ b/oauth2_and_accelo_api_connector_multithreading_enabled/README.md
@@ -21,7 +21,7 @@ This example was contributed by community member Ahmed Zedan. For the API refere
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -62,7 +62,7 @@ The connector requires the following configuration parameters:
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/odata_api/README.md
+++ b/odata_api/README.md
@@ -14,7 +14,7 @@ Each sub-implementation includes its own `connector.py`, `ODataClient.py` (where
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])

--- a/oktopost/README.md
+++ b/oktopost/README.md
@@ -6,7 +6,7 @@ The Oktopost connector fetches export metadata and CSV data from the Oktopost BI
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -55,7 +55,7 @@ Configuration parameters:
 - `base_url` (optional): Custom API base URL (defaults to https://api.oktopost.com/v2)
 - `test_export_id` (optional): Specific export ID for testing purposes
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/owasp_api_vulns/README.md
+++ b/owasp_api_vulns/README.md
@@ -14,7 +14,7 @@ The OWASP API Vulnerabilities connector was developed as part of Ashish's submis
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -64,7 +64,7 @@ The connector requires the following configuration parameters in the `configurat
 - `logging_level` (optional) - Set to `standard` for summary logging or `debug` for verbose, detailed logging. Defaults to `debug`.
 - `cwe_ids` (optional) - A comma-separated string of CWE IDs to filter the vulnerabilities. Defaults to a predefined list of OWASP-related CWEs.
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/partech/README.md
+++ b/partech/README.md
@@ -8,7 +8,7 @@ The connector fetches location settings, program rules, redeemables (rewards), a
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -58,7 +58,7 @@ Configuration parameters:
 | `location_key` | Your location-specific API key obtained from Partech. | Yes |
 | `business_key` | Your business-wide API key obtained from Partech. | Yes |
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Authentication
 

--- a/pindrop/README.md
+++ b/pindrop/README.md
@@ -6,7 +6,7 @@ The Pindrop connector for Fivetran fetches nightly reports from the Pindrop API 
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)   
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)   
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -48,7 +48,7 @@ The connector requires OAuth2 client credentials for authentication. The base UR
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/prefect/README.md
+++ b/prefect/README.md
@@ -6,7 +6,7 @@ This connector syncs workflow orchestration data from Prefect Cloud to your data
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -55,7 +55,7 @@ The connector requires the following configuration parameters:
 | `account_id` | string | Yes | Your Prefect Cloud account identifier. This can be found in your Prefect Cloud URL or account settings. |
 | `workspace_id` | string | Yes | Your Prefect Cloud workspace identifier. This specifies which workspace's data will be synced to your data warehouse. |
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -6,7 +6,7 @@ This connector syncs metrics metadata and time series data from Prometheus, an o
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -63,7 +63,7 @@ Configuration parameters:
 - `lookback_hours` (optional, defaults to 24) - Number of hours to look back for initial sync
 - `metrics_filter` (optional) - Comma-separated list or JSON array of specific metric names to sync. If omitted, all metrics are synced.
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/quest_db/README.md
+++ b/quest_db/README.md
@@ -6,7 +6,7 @@ This connector syncs high-performance time series data from QuestDB to your Five
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -63,7 +63,7 @@ Configuration parameters:
 - `batch_size` (optional) - Number of records to fetch per API request (defaults to `1000`)
 - `timestamp_column` (optional) - Column name for timestamp-based incremental sync (defaults to `timestamp`)
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/rabbitmq/README.md
+++ b/rabbitmq/README.md
@@ -6,7 +6,7 @@ This connector syncs messages from RabbitMQ queues to Fivetran. The connector re
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -52,7 +52,7 @@ The configuration keys required for your connector are as follows:
 - `queues` (required) - Comma-separated list of queue names to sync (for example: "orders,payments,notifications")
 - `batch_size` (optional) - Number of messages to process per batch (defaults to 100)
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/raven_db/README.md
+++ b/raven_db/README.md
@@ -8,7 +8,7 @@ The connector is designed to handle large datasets efficiently through streaming
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -57,7 +57,7 @@ fivetran init --template raven_db
 
 > Note: You must provide the certificate as a base64-encoded PEM certificate string.
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/redis/README.md
+++ b/redis/README.md
@@ -22,7 +22,7 @@ This connector is NOT suitable for:
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -95,7 +95,7 @@ The configuration keys required for your connector are as follows:
 - `"game:*:stats"` - All game statistics
 - `"achievement:*"` - All achievement data
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/redshift/large_data_volume/README.md
+++ b/redshift/large_data_volume/README.md
@@ -6,7 +6,7 @@ This example connector demonstrates how to sync large tables from Amazon Redshif
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -69,7 +69,7 @@ The parameters include:
 - `enable_complete_resync`: A boolean flag that defines whether each sync is a [full re-sync](https://fivetran.com/docs/using-fivetran/features#fullresync).
 - `max_parallel_workers`: The maximum number of parallel workers to use for data extraction. We recommend setting this value between 2 and 4. Setting it too high may lead to potential performance degradation.
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/redshift/simple_redshift_connector/README.md
+++ b/redshift/simple_redshift_connector/README.md
@@ -6,7 +6,7 @@ This connector demonstrates how to sync records from a Redshift database using t
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -46,7 +46,7 @@ The connector requires the following configuration parameters:
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/redshift/using_unload/README.md
+++ b/redshift/using_unload/README.md
@@ -6,7 +6,7 @@ This example connector demonstrates how to efficiently sync large tables from Am
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -62,7 +62,7 @@ The configuration file (`configuration.json`) contains the necessary parameters 
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ### Configuration parameters
 

--- a/resend/README.md
+++ b/resend/README.md
@@ -6,7 +6,7 @@ This connector demonstrates how to fetch email data from Resend and upsert it in
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -50,7 +50,7 @@ The configuration key required for your connector is as follows:
 
 - `api_token` (required) - Your Resend API token for authentication.
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/rethink_db/README.md
+++ b/rethink_db/README.md
@@ -6,7 +6,7 @@ This example demonstrates how to use the Fivetran Connector SDK to sync data fro
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -60,7 +60,7 @@ Configuration parameters:
 - `password`: Password for authentication (optional, leave empty for unauthenticated connections)
 - `use_ssl`: Enable SSL/TLS encryption for secure connections (true or false, defaults to false)
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/s3_csv_validation/README.md
+++ b/s3_csv_validation/README.md
@@ -17,7 +17,7 @@ This example is ideal for:
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -66,7 +66,7 @@ The connector requires the following configuration parameters:
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/sam_gov/README.md
+++ b/sam_gov/README.md
@@ -6,7 +6,7 @@ This connector fetches government contracting opportunities from the SAM.gov (Sy
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -99,7 +99,7 @@ Sync 3 (long downtime - ~2 years): [02/14/2025 - 12/17/2026] (30-day overlap, 67
   → State saves: last_posted_to = 12/17/2026
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/sap_ariba/README.md
+++ b/sap_ariba/README.md
@@ -8,7 +8,7 @@ This connector uses the SAP Ariba Sandbox API for illustration, but it can be ad
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -50,7 +50,7 @@ The connector reads configuration values from `configuration.json`, which define
 Key descriptions:
 - `api_key` (required) – SAP Ariba API key used for authentication.
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/sap_hana_sql/README.md
+++ b/sap_hana_sql/README.md
@@ -6,7 +6,7 @@ This connector extracts data from a SAP HANA database using the `hdbcli`. The co
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -48,7 +48,7 @@ The connector requires the following configuration parameters:
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/sendcloud/README.md
+++ b/sendcloud/README.md
@@ -6,7 +6,7 @@ This connector integrates with the Sendcloud API to extract shipment data includ
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -55,7 +55,7 @@ Configuration parameters:
 - `start_date`: ISO date to begin synchronization in YYYY-MM-DD format (required)
 - `use_mock_server`: Set to "true" to use Stoplight mock server for testing, "false" for production API (optional, defaults to "false")
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/sensor_tower/README.md
+++ b/sensor_tower/README.md
@@ -6,7 +6,7 @@ This example demonstrates how to build a Fivetran Connector SDK integration for 
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -44,7 +44,7 @@ The connector expects a `configuration.json` file with the following structure:
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/sensource/README.md
+++ b/sensource/README.md
@@ -15,7 +15,7 @@ The connector processes data in 30-day chunks to handle large historical dataset
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -70,7 +70,7 @@ Configuration parameters:
 - `static_endpoints` (optional): Comma-separated list of static endpoints to sync (default: "location,site,zone,space").
 - `start_date` (optional): Start date for historical data collection in YYYY-MM-DD format (default: "2022-01-01").
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/similarweb/README.md
+++ b/similarweb/README.md
@@ -6,7 +6,7 @@ This example demonstrates how to build a Fivetran Connector SDK integration for 
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -44,7 +44,7 @@ The connector expects a `configuration.json` file with the following structure:
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/smartsheets/README.md
+++ b/smartsheets/README.md
@@ -6,7 +6,7 @@ This connector demonstrates how to sync row-level data from Smartsheet using the
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -48,7 +48,7 @@ The connector requires the following configuration parameters:
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/snipeitapp/README.md
+++ b/snipeitapp/README.md
@@ -6,7 +6,7 @@ This connector demonstrates how to integrate Snipe-IT Asset Management data with
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -52,7 +52,7 @@ The connector requires the following configuration parameters:
 - `api_token` (required): Your Snipe-IT Bearer token for API authentication with read permissions for all resources you want to sync
 - `base_url` (required): The base URL of your Snipe-IT instance (e.g., `https://your-snipeit-instance.com` for cloud or `http://localhost:8000` for self-hosted)
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/solace/README.md
+++ b/solace/README.md
@@ -6,7 +6,7 @@ This connector demonstrates how to sync data from a Solace queue using the [Five
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -50,7 +50,7 @@ The connector expects the following configuration in the `configuration.json` fi
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/sql_server/README.md
+++ b/sql_server/README.md
@@ -13,7 +13,7 @@ This example covers:
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -55,7 +55,7 @@ The connector requires the following configuration parameters:
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/status_cake/README.md
+++ b/status_cake/README.md
@@ -6,7 +6,7 @@ This connector fetches uptime monitoring data from [StatusCake](https://app.stat
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -46,7 +46,7 @@ The configuration requires your StatusCake API key for authentication. You can o
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/suitedash/README.md
+++ b/suitedash/README.md
@@ -6,7 +6,7 @@ This example shows how to use Connector SDK to extract companies, contacts, and 
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -47,7 +47,7 @@ The configuration file defines the authentication credentials required to connec
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -6,7 +6,7 @@ This connector demonstrates how to fetch employee data from a Supabase database 
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -60,7 +60,7 @@ The configuration requires your Supabase project URL and API key to establish a 
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/talon_one/README.md
+++ b/talon_one/README.md
@@ -8,7 +8,7 @@ The connector maintains one table, `event`. This table contains application even
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -49,7 +49,7 @@ The connector requires configuration with your Talon.one credentials and sync se
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/teradata/README.md
+++ b/teradata/README.md
@@ -6,7 +6,7 @@ This connector demonstrates how to use the Fivetran Connector SDK to extract dat
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -46,7 +46,7 @@ The connector uses a configuration file to specify connection details and table 
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/tidb/README.md
+++ b/tidb/README.md
@@ -15,7 +15,7 @@ This example was contributed by [Nikhil Mankani](https://www.linkedin.com/in/nik
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -58,7 +58,7 @@ The connector expects a `configuration.json` file when running locally.
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 Configuration parameters:
 

--- a/timescale_db/README.md
+++ b/timescale_db/README.md
@@ -6,7 +6,7 @@ The TimescaleDB connector allows you to extract time-series data and vector data
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -48,7 +48,7 @@ The connector requires the following configuration parameters in your `configura
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/toast/README.md
+++ b/toast/README.md
@@ -4,7 +4,7 @@
 
 This is a custom [Fivetran connector](https://fivetran.com/docs/connectors/connector-sdk) implementation to extract and sync data from the [Toast POS API](https://doc.toasttab.com/) into a destination warehouse. Toast is a restaurant management platform providing point-of-sale, labor, menu, and operational data.
 
-For full implementation details, see the [Toast connector example code](https://github.com/fivetran/fivetran-csdk-connectors/tree/main/toast/).
+For full implementation details, see the [Toast connector example code](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/toast/).
 
 ## Requirements
 
@@ -12,7 +12,7 @@ For full implementation details, see the [Toast connector example code](https://
 - Domain to connect to (e.g., `api.toasttab.com`)
 - A Fernet key (`key`) for encrypting access tokens
 - `initialSyncStart` ISO timestamp to define the start of sync window
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 
 ## Getting started
 
@@ -52,7 +52,7 @@ Example `configuration.json`:
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/tulip_interfaces/README.md
+++ b/tulip_interfaces/README.md
@@ -8,7 +8,7 @@ To use this connector, you need access to a Tulip instance and a Tulip API key w
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -70,7 +70,7 @@ Configuration parameters:
 
 > Note: The connector automatically excludes Linked Table Fields (`tableLink` type) to reduce database load on the Tulip API. System fields (`id`, `_createdAt`, `_updatedAt`, `_sequenceNumber`) and all non-`tableLink` custom fields are always included.
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/veeva_vault/basic_auth/README.md
+++ b/veeva_vault/basic_auth/README.md
@@ -16,7 +16,7 @@ See [Veeva Vault API documentation](https://developer.veevavault.com/api/19.3/) 
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -57,7 +57,7 @@ The connector requires the following configuration parameters:
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/veeva_vault/session_id_auth/README.md
+++ b/veeva_vault/session_id_auth/README.md
@@ -16,7 +16,7 @@ See [Veeva Vault API documentation](https://developer.veevavault.com/api/19.3/) 
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -57,7 +57,7 @@ The connector requires the following configuration parameters:
 }
 ```
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/vercel/README.md
+++ b/vercel/README.md
@@ -6,7 +6,7 @@ This connector demonstrates how to fetch deployment data from [Vercel](https://v
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -50,7 +50,7 @@ The configuration keys required for your connector are as follows:
 - `api_token` (required): Your Vercel access token for API authentication
 - `team_id` (optional): Team identifier to access team resources instead of a personal account. If not provided, the connector accesses your personal account resources.
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/yugabyte_db/README.md
+++ b/yugabyte_db/README.md
@@ -8,7 +8,7 @@ YugabyteDB is particularly popular for IoT sensor data, real-time analytics, tim
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -69,7 +69,7 @@ Configuration parameters:
 - `schema` (optional) - Database schema to sync (default: `public`).
 - `sslmode` (optional) - SSL mode (possible values: `require`, `prefer`, `allow`, `disable`).
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 

--- a/zigpoll/README.md
+++ b/zigpoll/README.md
@@ -6,7 +6,7 @@ This connector retrieves survey response data from [Zigpoll](https://apidocs.zig
 
 ## Requirements
 
-- [Supported Python versions](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/README.md#requirements)
+- [Supported Python versions](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/README.md#requirements)
 - Operating system:
   - Windows: 10 or later (64-bit only)
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
@@ -52,7 +52,7 @@ Configuration parameters:
 - `api_token` (required): Your Zigpoll API authentication token
 - `start_date` (optional): Date in YYYY-MM-DD format to start syncing data from (e.g., `"2023-01-01"`). If not provided, sync will start from EPOCH time
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran-csdk-connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran-csdk-connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 


### PR DESCRIPTION
Closes https://fivetran.atlassian.net/browse/RD-1196196

### Description of Change
Converting links:
- fivteran-csdk-connectors to fivetran_csdk_connectors
- Converting relative links to absolute

### Testing
NA

### Checklist
Some tips and links to help validate your PR:

- [x] Tested the connector with `fivetran debug` command.
- [x] Added/Updated example-specific README.md file, see [the README template](https://github.com/fivetran/fivetran-csdk-connectors/tree/main/_template_connector/README_template.md) for the required structure and guidelines.
- [x] Followed Python Coding Standards, [refer here](https://github.com/fivetran/fivetran-csdk-connectors/blob/main/PYTHON_CODING_STANDARDS.md)