### PR TITLE
Fix(readme) : fixing all the readme.md as they did not follow the standard template 

### DIFF
--- a/aws_dynamo_db_authentication/README.md
+++ b/aws_dynamo_db_authentication/README.md
@@ -71,10 +71,13 @@ boto3==1.37.4
 
 ## Authentication
 
-This connector authenticates by:
-- Using `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` to create an STS client.
-- Calling `sts.assume_role()` with the `ROLE_ARN`.
-- Using the assumed role's credentials to access DynamoDB.
+This connector authenticates using AWS IAM role assumption via STS. To set up the required credentials:
+
+1. In the AWS Console, create an IAM user with programmatic access and save the generated `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
+2. Create an IAM role (or choose an existing one) and attach the `AmazonDynamoDBFullAccess` policy to it.
+3. Edit the role's trust policy to allow the IAM user to assume it.
+4. Copy the role ARN (format: `arn:aws:iam::<account-id>:role/<role-name>`).
+5. Set `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `ROLE_ARN`, and `REGION` in `configuration.json`.
 
 ## Pagination
 

--- a/documentdb/README.md
+++ b/documentdb/README.md
@@ -18,6 +18,21 @@ The connector is designed to handle large datasets efficiently through streaming
   - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
   - Linux: Distributions such as Ubuntu 20.04 or later, Debian 10 or later, or Amazon Linux 2 or later (arm64 or x86_64)
 
+## Prerequisites
+
+This connector requires that the following prerequisites exist in your DocumentDB instance:
+
+- A database named as specified in the `configuration.json` file
+- A `users` collection with documents containing `_id` (ObjectId), `name` (string), `email` (string), `status` (string), `created_at` (datetime), `updated_at` (datetime), and `metadata` (object) fields
+- An `orders` collection with documents containing `_id` (ObjectId), `user_id` (string), `order_number` (string), `total_amount` (number), `status` (string), `created_at` (datetime), `updated_at` (datetime), and `items` (array) fields
+
+Example document structures:
+
+```json
+{ "_id": "ObjectId(...)", "name": "John Doe", "email": "john@example.com", "status": "active", "created_at": "ISODate(...)", "updated_at": "ISODate(...)", "metadata": { "source": "web" } }
+{ "_id": "ObjectId(...)", "user_id": "user123", "order_number": "ORD-001", "total_amount": 99.99, "status": "completed", "created_at": "ISODate(...)", "updated_at": "ISODate(...)", "items": [{ "product": "Widget", "quantity": 2 }] }
+```
+
 ## Getting started
 
 Refer to the [Connector SDK Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
@@ -56,11 +71,11 @@ The connector requires the following configuration parameters:
 }
 ```
 
-- hostname: The DocumentDB cluster endpoint hostname
-- username: Username for authentication
-- password: Password for authentication
-- database: The DocumentDB database name to connect to
-- port: The port number for the DocumentDB cluster (default: 27017)
+- `hostname` – The DocumentDB cluster endpoint hostname
+- `username` – Username for authentication
+- `password` – Password for authentication
+- `database` – The DocumentDB database name to connect to
+- `port` – The port number for the DocumentDB cluster (default: 27017)
 
 > Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
@@ -79,10 +94,10 @@ python-dateutil
 
 The connector uses SSL authentication with DocumentDB. Provide the following credentials in the configuration:
 
-- username: A valid DocumentDB user with read permissions on the specified database
-- password: The corresponding password for the user
+- `username` – A valid DocumentDB user with read permissions on the specified database
+- `password` – The corresponding password for the user
 
-The connector automatically configures SSL settings required for DocumentDB connections.
+The connector automatically configures SSL settings required for DocumentDB connections. The connection string includes `retryWrites=false`, which is required by DocumentDB.
 
 ## Pagination
 
@@ -101,14 +116,6 @@ The connector processes data with the following approach:
 - Handles timezone-aware datetime objects consistently across queries and comparisons
 - Uses MongoDB query syntax with `$gt` operator for efficient incremental querying
 - Maintains state between runs by tracking the latest timestamp processed
-- Delivers data with the following schema mapping:
-  - _id (ObjectId → STRING)
-  - name (string → STRING)
-  - email (string → STRING)
-  - status (string → STRING)
-  - created_at (datetime → UTC_DATETIME)
-  - updated_at (datetime → UTC_DATETIME)
-  - metadata (object → JSON)
 
 ## Error handling
 
@@ -127,49 +134,20 @@ This connector creates the following tables in your destination:
 
 ### USERS
 
-- Primary key: `_id`
-- Columns:
-  - `_id` (STRING): Document unique identifier
-  - `created_at` (UTC_DATETIME): Document creation timestamp
-  - `updated_at` (UTC_DATETIME): Document last update timestamp
-  - `metadata` (JSON): Additional user metadata as JSON object
+- `_id` (STRING, primary key) – Document unique identifier
+- `created_at` (UTC_DATETIME) – Document creation timestamp
+- `updated_at` (UTC_DATETIME) – Document last update timestamp
+- `metadata` (JSON) – Additional user metadata as JSON object
 
 ### ORDERS
 
-- Primary key: `_id`
-- Columns:
-  - `_id` (STRING): Document unique identifier
-  - `created_at` (UTC_DATETIME): Order creation timestamp
-  - `updated_at` (UTC_DATETIME): Order last update timestamp
-  - `items` (JSON): Order items as JSON array
-
-## Prerequisites
-
-This connector requires that the following prerequisites exist in your DocumentDB instance:
-
-- A database named as specified in your configuration
-- Collections with documents containing the following fields:
-   - `_id` (ObjectId): Primary key
-   - `updated_at` (datetime): Document update timestamp for incremental sync
-   - Other fields as defined in your schema
-
-Example document structure:
-```json
-{
-  "_id": ObjectId("..."),
-  "created_at": ISODate("2023-01-01T00:00:00Z"),
-  "updated_at": ISODate("2023-01-01T00:00:00Z"),
-  "metadata": {"source": "web"}
-}
-```
+- `_id` (STRING, primary key) – Document unique identifier
+- `created_at` (UTC_DATETIME) – Order creation timestamp
+- `updated_at` (UTC_DATETIME) – Order last update timestamp
+- `items` (JSON) – Order items as JSON array
 
 ## Additional considerations
 
 The examples provided are intended to help you effectively use Fivetran's Connector SDK. While we've tested the code, Fivetran cannot be held responsible for any unexpected or negative consequences that may arise from using these examples. For inquiries, please reach out to our Support team.
 
-### DocumentDB-specific notes
-
-- DocumentDB is MongoDB-compatible, so this connector uses the PyMongo driver
-- SSL is required for DocumentDB connections and is automatically configured
-- The connector uses `retryWrites=false` in the connection string as required by DocumentDB
-- DocumentDB has some limitations compared to MongoDB, but this connector works within those constraints
+DocumentDB is MongoDB-compatible, so this connector uses the PyMongo driver. DocumentDB has some limitations compared to MongoDB, but this connector works within those constraints.

--- a/documentdb/README.md
+++ b/documentdb/README.md
@@ -75,7 +75,7 @@ The connector requires the following configuration parameters:
 - `username` – Username for authentication
 - `password` – Password for authentication
 - `database` – The DocumentDB database name to connect to
-- `port` – The port number for the DocumentDB cluster (default: 27017)
+- `port` – The port number for the DocumentDB cluster (default: `27017`)
 
 > Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_csdk_connectors/tree/main) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_csdk_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 

--- a/firebird_db/README.md
+++ b/firebird_db/README.md
@@ -86,9 +86,9 @@ The connector processes data in the following way:
 The connector uses incremental sync based on table-specific incremental columns to avoid duplicate data and ensure efficient synchronization.
 
 The connector includes several configurable performance parameters:
-- `batch_process_size` – Number of records processed per upsert (default: 1000)
-- `batch_query_size` – Number of records retrieved per query (default: 10000)
-- `MAX_WORKERS` – Maximum number of concurrent threads (default: 10)
+- `batch_process_size` – Number of records processed per upsert (default: `1000`)
+- `batch_query_size` – Number of records retrieved per query (default: `10000`)
+- `MAX_WORKERS` – Maximum number of concurrent threads (default: `10`)
 
 ## Error handling
 

--- a/firebird_db/README.md
+++ b/firebird_db/README.md
@@ -85,6 +85,11 @@ The connector processes data in the following way:
 
 The connector uses incremental sync based on table-specific incremental columns to avoid duplicate data and ensure efficient synchronization.
 
+The connector includes several configurable performance parameters:
+- `batch_process_size` – Number of records processed per upsert (default: 1000)
+- `batch_query_size` – Number of records retrieved per query (default: 10000)
+- `MAX_WORKERS` – Maximum number of concurrent threads (default: 10)
+
 ## Error handling
 
 The connector implements error handling for:
@@ -119,32 +124,7 @@ Incremental column: `DATE_MODIFIED`
 
 ## Additional files
 
-The connector uses a separate **`schema.py`** file to define tables and their configuration:
-
-```python
-table_list = [
-    {
-        "table_name": "table_1",
-        "incremental_column": "ID",
-        "primary_key": ["ID"]
-    },
-    {
-        "table_name": "table_2",
-        "incremental_column": "DATE_MODIFIED",
-        "primary_key": ["ID"]
-    },
-    {
-        "table_name": "table_3",
-        "incremental_column": "DATE_MODIFIED",
-        "primary_key": ["ID"]
-    }
-]
-```
-
-The connector includes several configurable performance parameters:
-- `batch_process_size`: Number of records processed per upsert (default: 1000)
-- `batch_query_size`: Number of records retrieved per query (default: 10000)
-- `MAX_WORKERS`: Maximum number of concurrent threads (default: 10)
+- [`schema.py`](schema.py) – Defines the list of Firebird tables to sync, with each entry specifying the table name, primary key columns, and incremental sync column.
 
 ## Additional considerations
 

--- a/fleetio/README.md
+++ b/fleetio/README.md
@@ -40,8 +40,8 @@ You can generate your Account Token and API Key [here](https://secure.fleetio.co
 
 ```json
 {
-    "Account-Token": "<accountToken>",
-    "Authorization": "Token <ApiKey>"
+    "Account-Token": "<YOUR_ACCOUNT_TOKEN>",
+    "Authorization": "Token <YOUR_API_KEY>"
 }
 ```
 
@@ -84,7 +84,7 @@ The following tables are synced to the destination:
 - `issues` – Issues in Fleetio allows users to log and track unexpected, unplanned, or "one-time" problems and repairs.
 - `parts` – Parts management is key to running an efficient fleet. Fleetio makes it easy to keep track of Parts data, including Part Manufacturer, Vendor, and Location.
 - `purchase_orders` – Purchase Orders in Fleetio are designed to help standardize Parts procurement through a purchasing workflow.
-- `service_entries` – Service Entries are a simple way to log completed Service Tasks and Issues-the routine Preventative Maintenance and one-time repairs that are performed on Vehicles in Fleetio.
+- `service_entries` – Service Entries are a simple way to log completed Service Tasks and Issues — the routine Preventative Maintenance and one-time repairs that are performed on Vehicles in Fleetio.
 - `submitted_inspection_forms` – Submitted Inspection Forms are Inspection Forms that have been completed and submitted.
 - `vehicles` – A "vehicle" represents any asset or unit of equipment-moving or otherwise-managed in Fleetio.
 

--- a/fleetio/README.md
+++ b/fleetio/README.md
@@ -86,7 +86,15 @@ The following tables are synced to the destination:
 - `purchase_orders` – Purchase Orders in Fleetio are designed to help standardize Parts procurement through a purchasing workflow.
 - `service_entries` – Service Entries are a simple way to log completed Service Tasks and Issues — the routine Preventative Maintenance and one-time repairs that are performed on Vehicles in Fleetio.
 - `submitted_inspection_forms` – Submitted Inspection Forms are Inspection Forms that have been completed and submitted.
-- `vehicles` – A "vehicle" represents any asset or unit of equipment-moving or otherwise-managed in Fleetio.
+- `CONTACTS` – A contact is a person employed by your organization or a person with whom your organization does business.
+- `EXPENSE_ENTRIES` – An expense entry is a record of a cost associated with a vehicle.
+- `FUEL_ENTRIES` – Fuel entries represent a fuel transaction in Fleetio and are an important feature to maximize your data. They contain all of the relevant information for the fuel-up, such as vendor and odometer information.
+- `ISSUES` – Issues in Fleetio allows users to log and track unexpected, unplanned, or "one-time" problems and repairs.
+- `PARTS` – Parts management is key to running an efficient fleet. Fleetio makes it easy to keep track of parts data, including part manufacturer, vendor, and location.
+- `PURCHASE_ORDERS` – Purchase orders in Fleetio are designed to help standardize parts procurement through a purchasing workflow.
+- `SERVICE_ENTRIES` – Service entries are a simple way to log completed service tasks and issues — the routine preventative maintenance and one-time repairs that are performed on vehicles in Fleetio.
+- `SUBMITTED_INSPECTION_FORMS` – Submitted inspection forms are Inspection forms that have been completed and submitted.
+- `VEHICLES` – A vehicle represents any asset or unit of equipment-moving or otherwise-managed in Fleetio.
 
 ## Additional considerations
 

--- a/gcp_pub_sub/README.md
+++ b/gcp_pub_sub/README.md
@@ -114,7 +114,7 @@ The connector implements error handling at multiple levels:
 
 - Validates that all required configuration parameters are present
 - Topic creation – Handles `AlreadyExists` exception gracefully when creating test topics
-- Wraps message processing in try-except blocks to catch and report errors during:
+- Wraps each message batch in a try-except block to handle errors during payload parsing, record upsert, and message acknowledgment.
 - All exceptions are re-raised as `RuntimeError` with contextual error messages for debugging.
 
 ## Tables created

--- a/gnews/README.md
+++ b/gnews/README.md
@@ -63,7 +63,7 @@ This connector does not require any additional packages beyond those provided by
 
 The connector authenticates with the GNews API using an API key passed as a query parameter in each request. To obtain an API key:
 
-1. Register for an account at [gnews.io](https://gnews.io).
+1. Sign up for the [GNews API](https://gnews.io/register).
 2. Verify your email address to activate your account and unlock API access.
 3. Log in and navigate to your dashboard.
 4. Copy your API key and set it as `api_key` in `configuration.json`.

--- a/gnews/README.md
+++ b/gnews/README.md
@@ -59,6 +59,23 @@ This connector does not require any additional packages beyond those provided by
 
 > Note: [Some packages](https://fivetran.com/docs/connector-sdk/technical-reference#preinstalledpackages) are pre-installed in the Connector SDK runtime environment. To avoid dependency conflicts, do not declare them in your `requirements.txt`.
 
+## Authentication
+
+The connector authenticates with the GNews API using an API key passed as a query parameter in each request. To obtain an API key:
+
+1. Register for an account at [gnews.io](https://gnews.io).
+2. Verify your email address to activate your account and unlock API access.
+3. Log in and navigate to your dashboard.
+4. Copy your API key and set it as `api_key` in `configuration.json`.
+
+## Pagination
+
+The connector iterates through pages of GNews search results using the `page` query parameter in `fetch_all_news()`, starting at page 1 and incrementing on each request. Paging stops when one of the following conditions is met:
+
+- A page returns zero articles.
+- The cumulative upsert count equals `totalArticles` from the API response.
+- The optional `max_pages` cap is reached.
+
 ## Data handling
 
 - Data normalization: `normalize_articles` flattens each `articles[*]` object and maps:


### PR DESCRIPTION
Closes  https://fivetran.atlassian.net/jira/software/c/projects/RD/boards/608?selectedIssue=RD-1190849

### Description of Change
   - Fixed `documentdb` README: moved Prerequisites before Getting started, removed nested bullets and duplicated schema mapping, flattened Tables created, merged DocumentDB-specific notes inline
   - Fixed `gnews` README: added missing Authentication (with API key steps) and Pagination sections before Data handling
   - Fixed `aws_dynamo_db_authentication` README: rewrote Authentication section with numbered IAM setup steps
   - Fixed `fleetio` README: updated config placeholders to `<YOUR_…>` format; fixed `Issues-the` typo in service_entries description
   - Fixed `gcp_pub_sub` README: rewrote dangling colon bullet in Error handling as a complete sentence
   - Fixed `firebird_db` README: replaced inlined schema.py code block with a linked file description; moved configurable performance parameters to Data handling
   
### Testing
None 

### Checklist
Some tips and links to help validate your PR:

- [ ] Tested the connector with `fivetran debug` command.
- [ ] Added/Updated example-specific README.md file, see [the README template](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/_template_connector/README_template.md) for the required structure and guidelines.
- [ ] Followed Python Coding Standards, [refer here](https://github.com/fivetran/fivetran_csdk_connectors/blob/main/PYTHON_CODING_STANDARDS.md)