### PR TITLE
GA-1029637-update-github-pipeline

### DIFF
--- a/.github/workflows/add-label.yml
+++ b/.github/workflows/add-label.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Label PR by size
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ github.token }}
           script: |
@@ -61,7 +61,7 @@ jobs:
             }
 
       - name: Add default risk and ai-assisted labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ github.token }}
           script: |

--- a/.github/workflows/add-label.yml
+++ b/.github/workflows/add-label.yml
@@ -4,8 +4,7 @@ on:
     types: [ opened, synchronize, reopened ]
 
 permissions:
-  contents: read
-  pull-requests: write
+  pull-requests: read
   issues: write
 
 jobs:

--- a/.github/workflows/add-label.yml
+++ b/.github/workflows/add-label.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Label PR by size
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
           script: |
             const THRESHOLDS = [
               { max: 19,   label: "size/XS" },
@@ -63,7 +63,7 @@ jobs:
       - name: Add default risk and ai-assisted labels
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
           script: |
             const { owner, repo } = context.repo;
             const prNumber = context.payload.pull_request.number;

--- a/.github/workflows/code-quality-check.yml
+++ b/.github/workflows/code-quality-check.yml
@@ -3,6 +3,10 @@ name: Python
 on:
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   code-quality-check:
     name: Check Code Quality
@@ -10,16 +14,18 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: '3.13'
 
       - name: Install dependencies
         run: |
-          pip install flake8 black
+          pip install black==26.5.1 flake8==7.3.0
 
       - name: Run black and generate diff
         id: black_check
@@ -37,96 +43,164 @@ jobs:
 
       - name: Upload formatting.diff
         if: steps.black_check.outputs.black_failed == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: python-formatting-diff
           path: formatting.diff
 
-      - name: Detect changed Python files
-        id: detect_changes
+      - name: Run Flake8 on changed Python files
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          PR_NUMBER="${{ github.event.pull_request.number }}"
-          REPO="${{ github.repository }}"
-
-          # Fetch PR files and filter out removed files (only keep added, modified, renamed)
-          curl -s -f -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/${REPO}/pulls/${PR_NUMBER}/files" \
-            | jq -r '.[] | select(.status != "removed") | .filename' > all_files.txt
-
-          grep '\.py$' all_files.txt > changed_files.txt || true
-
-          if [[ ! -s changed_files.txt ]]; then
-            echo "No Python files changed."
-            echo "SKIP=true" >> $GITHUB_ENV
-          else
-            echo "SKIP=false" >> $GITHUB_ENV
-            echo "CHANGED=$(cat changed_files.txt | xargs)" >> $GITHUB_ENV
-          fi
-
-      - name: Run Flake8 on changed files
-        if: env.SKIP == 'false'
-        run: |
-          echo "Running flake8 on: $CHANGED"
-          flake8 $CHANGED > flake8_output.txt || true
-
-      - name: Format Flake8 results as PR comment
-        if: env.SKIP == 'false'
-        run: |
-          python3 <<'EOF' > flake8_summary.md
+          python3 <<'EOF'
+          import json
           import os
+          import pathlib
+          import subprocess
+          import urllib.request
 
-          try:
-              with open("flake8_output.txt") as f:
-                lines = f.read().splitlines()
-              
-          except FileNotFoundError:
-              lines = []
+          with open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8") as event_file:
+              event = json.load(event_file)
 
-          print("### 🧹 Python Code Quality Check\n")
-          run_url = f"https://github.com/{os.environ['GITHUB_REPOSITORY']}/actions/runs/{os.environ['GITHUB_RUN_ID']}"
+          repo = os.environ["GITHUB_REPOSITORY"]
+          pr_number = event["pull_request"]["number"]
+          token = os.environ["GH_TOKEN"]
+          changed_files = []
+          page = 1
+          run_url = (
+              f"https://github.com/{os.environ['GITHUB_REPOSITORY']}"
+              f"/actions/runs/{os.environ['GITHUB_RUN_ID']}"
+          )
 
-          if not lines:
-              print("✅ No issues found in Python Files.")
-              issue_present = False
-          else:
-              issue_present = True
-              print("⚠️ **Flake8 has detected issues, please fix the issues before merging:**")
-              print(f"\n📎 [Download full report from workflow artifacts]({run_url}).")  
-              print()
-              print("📌 _Only Python files changed in this PR were checked._")
-              
-          print("\n_This comment is auto-updated with every commit._")
+          while True:
+              request = urllib.request.Request(
+                  f"https://api.github.com/repos/{repo}/pulls/{pr_number}/files"
+                  f"?per_page=100&page={page}",
+                  headers={
+                      "Accept": "application/vnd.github+json",
+                      "Authorization": f"Bearer {token}",
+                  },
+              )
+              with urllib.request.urlopen(request) as response:
+                  batch = json.load(response)
+              if not batch:
+                  break
 
-          # Export environment variable
-          with open(os.environ["GITHUB_ENV"], "a") as envf:
-              envf.write(f"FLAKE8_ISSUE_PRESENT={'true' if issue_present else 'false'}\n")
-              envf.write(f"RUN_URL={run_url}\n")
+              changed_files.extend(
+                  item["filename"]
+                  for item in batch
+                  if item.get("status") != "removed" and item["filename"].endswith(".py")
+              )
+              page += 1
+
+          if not changed_files:
+              print("No Python files changed.")
+              pathlib.Path("flake8_output.txt").write_text("", encoding="utf-8")
+              with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as env_file:
+                  env_file.write("SKIP=true\n")
+                  env_file.write("FLAKE8_ISSUE_PRESENT=false\n")
+                  env_file.write(f"RUN_URL={run_url}\n")
+              with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary:
+                  summary.write("### Python Code Quality Check\n\n")
+                  summary.write("Flake8 skipped: no Python files changed.\n")
+              raise SystemExit(0)
+
+          print("Running flake8 on:")
+          for filename in changed_files:
+              print(f"  {filename}")
+
+          result = subprocess.run(
+              ["flake8", "--", *changed_files],
+              stdout=subprocess.PIPE,
+              stderr=subprocess.STDOUT,
+              text=True,
+              check=False,
+          )
+
+          pathlib.Path("flake8_output.txt").write_text(result.stdout, encoding="utf-8")
+          print(result.stdout, end="")
+
+          issue_present = result.returncode != 0
+
+          with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as env_file:
+              env_file.write("SKIP=false\n")
+              env_file.write(f"FLAKE8_ISSUE_PRESENT={'true' if issue_present else 'false'}\n")
+              env_file.write(f"RUN_URL={run_url}\n")
+
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary:
+              summary.write("### Python Code Quality Check\n\n")
+              if issue_present:
+                  summary.write("**Flake8 detected issues. Fix them before merging.**\n\n")
+                  summary.write(f"[Download full report from workflow artifacts]({run_url}).\n")
+                  summary.write("\n_Only Python files changed in this PR were checked._\n")
+              else:
+                  summary.write("No issues found in changed Python files.\n")
+
+              summary.write("\n_This summary is updated with every commit._\n")
           EOF
 
       - name: Upload full report
         if: env.FLAKE8_ISSUE_PRESENT == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: python-code-quality-report
           path: flake8_output.txt
 
-      - name: Find existing comment
-        uses: peter-evans/find-comment@v4
-        id: find
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: github-actions[bot]
-          body-includes: "### 🧹 Python Code Quality Check"
+      - name: Generate PR comment summary
+        if: always()
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BLACK_FAILED: ${{ steps.black_check.outputs.black_failed == 'true' }}
+          FLAKE8_FAILED: ${{ env.FLAKE8_ISSUE_PRESENT == 'true' }}
+          SKIP: ${{ env.SKIP }}
+        run: |
+          python3 <<'EOF'
+          import json
+          import os
+          import pathlib
 
-      - name: Create or update PR comment
-        if: env.SKIP == 'false'
-        continue-on-error: true
-        uses: peter-evans/create-or-update-comment@v4
+          skip = os.environ.get("SKIP", "")
+          flake8_failed = os.environ.get("FLAKE8_FAILED") == "true"
+          flake8_output = pathlib.Path("flake8_output.txt")
+          flake8_issue_count = 0
+
+          if flake8_output.exists():
+              flake8_issue_count = len(
+                  [
+                      line
+                      for line in flake8_output.read_text(
+                          encoding="utf-8"
+                      ).splitlines()
+                      if line.strip()
+                  ]
+              )
+
+          summary = {
+              "schema_version": 1,
+              "pr_number": int(os.environ["PR_NUMBER"]),
+              "head_sha": os.environ["HEAD_SHA"],
+              "workflow_run_id": os.environ["GITHUB_RUN_ID"],
+              "summary_complete": skip in {"true", "false"},
+              "black_failed": os.environ.get("BLACK_FAILED") == "true",
+              "flake8_failed": flake8_failed,
+              "python_files_checked": skip == "false",
+              "flake8_issue_count": flake8_issue_count,
+          }
+
+          pathlib.Path("pr-comment-summary.json").write_text(
+              json.dumps(summary, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          EOF
+
+      - name: Upload PR comment summary
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          comment-id: ${{ steps.find.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body-path: flake8_summary.md
-          edit-mode: replace
+          name: python-pr-comment
+          path: pr-comment-summary.json
+          retention-days: 7
 
       - name: Fail if both black and flake8 failed
         if: steps.black_check.outputs.black_failed == 'true' && env.FLAKE8_ISSUE_PRESENT == 'true'
@@ -149,6 +223,6 @@ jobs:
       - name: Fail if only flake8 failed
         if: steps.black_check.outputs.black_failed != 'true' && env.FLAKE8_ISSUE_PRESENT == 'true'
         run: |
-          echo "❌  Issues detected in Python files. Please fix them before merging."
+          echo "Issues detected in Python files. Please fix them before merging."
           echo "Download the full report from here: $RUN_URL"
           exit 1

--- a/.github/workflows/code-quality-check.yml
+++ b/.github/workflows/code-quality-check.yml
@@ -14,12 +14,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.13'
 
@@ -43,7 +43,7 @@ jobs:
 
       - name: Upload formatting.diff
         if: steps.black_check.outputs.black_failed == 'true'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: python-formatting-diff
           path: formatting.diff
@@ -141,7 +141,7 @@ jobs:
 
       - name: Upload full report
         if: env.FLAKE8_ISSUE_PRESENT == 'true'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: python-code-quality-report
           path: flake8_output.txt
@@ -196,7 +196,7 @@ jobs:
 
       - name: Upload PR comment summary
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: python-pr-comment
           path: pr-comment-summary.json

--- a/.github/workflows/code-quality-check.yml
+++ b/.github/workflows/code-quality-check.yml
@@ -31,9 +31,10 @@ jobs:
         id: black_check
         run: |
           echo "Running black in check mode with diff output..."
-          black --check --diff --line-length 99 . > formatting.diff || true
+          black_exit=0
+          black --check --diff --line-length 99 . > formatting.diff 2>&1 || black_exit=$?
 
-          if [ -s formatting.diff ]; then
+          if [ "$black_exit" -ne 0 ]; then
             echo "Formatting issues detected:"
             cat formatting.diff
             echo "black_failed=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/code-quality-check.yml
+++ b/.github/workflows/code-quality-check.yml
@@ -49,7 +49,7 @@ jobs:
           REPO="${{ github.repository }}"
 
           # Fetch PR files and filter out removed files (only keep added, modified, renamed)
-          curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          curl -s -f -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             "https://api.github.com/repos/${REPO}/pulls/${PR_NUMBER}/files" \
             | jq -r '.[] | select(.status != "removed") | .filename' > all_files.txt
 

--- a/.github/workflows/code-quality-check.yml
+++ b/.github/workflows/code-quality-check.yml
@@ -95,8 +95,6 @@ jobs:
               print()
               print("📌 _Only Python files changed in this PR were checked._")
               
-          slab_doc = f"https://fivetran.slab.com/posts/connector-sdk-examples-pr-policy-and-python-coding-standards-yzr9ggss#hb2vk-linting"
-          print(f"\n🔍 [See how this check works]({slab_doc})")
           print("\n_This comment is auto-updated with every commit._")
 
           # Export environment variable

--- a/.github/workflows/enforce-readme-update.yml
+++ b/.github/workflows/enforce-readme-update.yml
@@ -62,7 +62,13 @@ jobs:
               
               // Parse the git diff output
               return gitDiff.trim().split('\n').filter(line => line).map(line => {
-                const [status, filename] = line.split('\t');
+                const fields = line.split('\t');
+                const status = fields[0];
+                const filename =
+                  status.startsWith('R') || status.startsWith('C') ? fields[2] : fields[1];
+                if (!filename) {
+                  throw new Error(`Unexpected git diff --name-status output: ${line}`);
+                }
                 return { status, filename };
               });
             } catch (error) {

--- a/.github/workflows/enforce-readme-update.yml
+++ b/.github/workflows/enforce-readme-update.yml
@@ -4,46 +4,61 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   check-readme-update:
     runs-on: ubuntu-latest
     name: Check Updates for New Examples
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0  # Fetch all history for proper diff
-
-      - name: Expose PR SHAs
-        run: |
-          echo "BASE_SHA=${{ github.event.pull_request.base.sha }}" >> $GITHUB_ENV
-          echo "HEAD_SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
-          echo "HEAD_REPO=${{ github.event.pull_request.head.repo.clone_url }}" >> $GITHUB_ENV
+          persist-credentials: false
 
       - name: Ensure SHAs are fetched
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.clone_url }}
         run: |
-          git fetch --no-tags --prune origin $BASE_SHA 
-          git fetch --no-tags --prune $HEAD_REPO $HEAD_SHA
+          git fetch --no-tags --prune origin "$BASE_SHA"
+          git fetch --no-tags --prune "$HEAD_REPO" "$HEAD_SHA"
 
       - name: Create check script
         id: create-script
         run: |
           cat > check-readme-update.js << 'EOF'
-          const fs = require('fs');
           const path = require('path');
-          const { execSync } = require('child_process');
+          const { execFileSync } = require('child_process');
+
+          const SHA_RE = /^[0-9a-f]{40}$/i;
+
+          function getRequiredSha(name) {
+            const value = process.env[name];
+            if (!SHA_RE.test(value || '')) {
+              console.error(`${name} is not a valid git SHA`);
+              process.exit(1);
+            }
+            return value;
+          }
 
           // Get the list of files changed in the PR
           function getChangedFiles() {
             try {
               // Get the base branch (target) of the PR
-              const baseSha = process.env.BASE_SHA;
+              const baseSha = getRequiredSha('BASE_SHA');
               // Get current branch (source) of the PR
-              const headSha = process.env.HEAD_SHA;
+              const headSha = getRequiredSha('HEAD_SHA');
               
               // Use Git directly to get all changed files between branches
-              const gitDiff = execSync(`git diff --name-status ${baseSha}...${headSha}`, 
-                                      { encoding: 'utf-8' });
+              const gitDiff = execFileSync(
+                'git',
+                ['diff', '--name-status', `${baseSha}...${headSha}`],
+                { encoding: 'utf-8' }
+              );
               
               // Parse the git diff output
               return gitDiff.trim().split('\n').filter(line => line).map(line => {
@@ -59,10 +74,11 @@ jobs:
           // Check if a directory exists before our PR
           function directoryExistsInBase(dirPath) {
             try {
-              const baseSha = process.env.BASE_SHA;
+              const baseSha = getRequiredSha('BASE_SHA');
               // Check if this directory exists in the base branch
-              const result = execSync(
-                `git ls-tree -d ${baseSha} ${dirPath}`,
+              const result = execFileSync(
+                'git',
+                ['ls-tree', '-d', baseSha, '--', dirPath],
                 { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'] }
               );
               return result.trim() !== '';
@@ -147,13 +163,20 @@ jobs:
           EOF
 
       - name: Run directory check script
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: node check-readme-update.js
 
       - name: Debug information
         if: always()
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.clone_url }}
         run: |
-          echo "BASE_SHA: $BASE_SHA"
-          echo "HEAD_SHA: $HEAD_SHA"
-          echo "HEAD_REPO: $HEAD_REPO"
+          printf 'BASE_SHA: %s\n' "$BASE_SHA"
+          printf 'HEAD_SHA: %s\n' "$HEAD_SHA"
+          printf 'HEAD_REPO: %s\n' "$HEAD_REPO"
           echo "Git Branches:"
           git branch -a

--- a/.github/workflows/enforce-readme-update.yml
+++ b/.github/workflows/enforce-readme-update.yml
@@ -13,7 +13,7 @@ jobs:
     name: Check Updates for New Examples
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0  # Fetch all history for proper diff
           persist-credentials: false

--- a/.github/workflows/python-pr-comment.yml
+++ b/.github/workflows/python-pr-comment.yml
@@ -140,7 +140,7 @@ jobs:
             });
 
             const existing = comments.find((comment) =>
-              comment.user?.type === "Bot" && comment.body?.includes(marker)
+              comment.user?.login === "github-actions[bot]" && comment.body?.includes(marker)
             );
 
             if (existing) {

--- a/.github/workflows/python-pr-comment.yml
+++ b/.github/workflows/python-pr-comment.yml
@@ -1,0 +1,160 @@
+name: Python PR Comment
+
+on:
+  workflow_run:
+    workflows: [Python]
+    types: [completed]
+
+permissions:
+  actions: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  comment:
+    name: Update PR Comment
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download PR comment summary
+        id: download_summary
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: python-pr-comment
+          path: ${{ runner.temp }}/python-pr-comment
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Create or update PR comment
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        env:
+          SUMMARY_PATH: ${{ runner.temp }}/python-pr-comment/pr-comment-summary.json
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const fs = require("fs");
+
+            const marker = "<!-- python-code-quality-check -->";
+            const run = context.payload.workflow_run;
+            const pullRequests = run.pull_requests || [];
+
+            if (run.event !== "pull_request" || pullRequests.length === 0) {
+              core.info("No pull request is associated with this workflow run.");
+              return;
+            }
+
+            const pr = pullRequests[0];
+            const issueNumber = pr.number;
+            const summaryPath = process.env.SUMMARY_PATH;
+            let summary = null;
+            let statusLines = [];
+
+            function assertBoolean(name, value) {
+              if (typeof value !== "boolean") {
+                throw new Error(`${name} must be a boolean`);
+              }
+            }
+
+            function validateSummary(candidate) {
+              if (candidate.schema_version !== 1) {
+                throw new Error("Unexpected PR comment summary schema version");
+              }
+              if (candidate.pr_number !== issueNumber) {
+                throw new Error("PR number in summary does not match workflow_run payload");
+              }
+              if (candidate.head_sha !== run.head_sha) {
+                throw new Error("Head SHA in summary does not match workflow_run payload");
+              }
+              if (String(candidate.workflow_run_id) !== String(run.id)) {
+                throw new Error("Run ID in summary does not match workflow_run payload");
+              }
+
+              assertBoolean("summary_complete", candidate.summary_complete);
+              assertBoolean("black_failed", candidate.black_failed);
+              assertBoolean("flake8_failed", candidate.flake8_failed);
+              assertBoolean("python_files_checked", candidate.python_files_checked);
+
+              if (
+                !Number.isInteger(candidate.flake8_issue_count) ||
+                candidate.flake8_issue_count < 0 ||
+                candidate.flake8_issue_count > 100000
+              ) {
+                throw new Error("Invalid flake8 issue count in summary");
+              }
+            }
+
+            if (fs.existsSync(summaryPath)) {
+              const stats = fs.statSync(summaryPath);
+              if (stats.size > 8192) {
+                throw new Error("PR comment summary artifact is too large");
+              }
+
+              summary = JSON.parse(fs.readFileSync(summaryPath, "utf8"));
+              validateSummary(summary);
+            }
+
+            if (summary && summary.summary_complete) {
+              statusLines = [
+                `Black: **${summary.black_failed ? "failed" : "passed"}**`,
+                summary.python_files_checked
+                  ? `Flake8: **${summary.flake8_failed ? "failed" : "passed"}** (${summary.flake8_issue_count} output line${summary.flake8_issue_count === 1 ? "" : "s"})`
+                  : "Flake8: **skipped** (no Python files changed)",
+              ];
+            } else if (summary) {
+              statusLines = [
+                "The Python workflow did not produce complete lint metadata.",
+                `Workflow conclusion: **${run.conclusion || "unknown"}**`,
+              ];
+            } else {
+              statusLines = [
+                "The Python workflow did not upload PR comment metadata.",
+                `Workflow conclusion: **${run.conclusion || "unknown"}**`,
+              ];
+            }
+
+            const details = [];
+            if (summary?.black_failed) {
+              details.push("Formatting diff is available in the workflow artifacts.");
+            }
+            if (summary?.flake8_failed) {
+              details.push("Flake8 report is available in the workflow artifacts.");
+            }
+
+            const body = [
+              marker,
+              "### Python Code Quality Check",
+              "",
+              ...statusLines,
+              "",
+              `[Workflow run](${run.html_url})`,
+              ...details.map((detail) => `- ${detail}`),
+              "",
+              "_This comment is auto-updated with every commit._",
+            ].join("\n");
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              per_page: 100,
+            });
+
+            const existing = comments.find((comment) =>
+              comment.user?.type === "Bot" && comment.body?.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body,
+              });
+            }

--- a/.github/workflows/python-pr-comment.yml
+++ b/.github/workflows/python-pr-comment.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Download PR comment summary
         id: download_summary
         continue-on-error: true
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: python-pr-comment
           path: ${{ runner.temp }}/python-pr-comment
@@ -26,7 +26,7 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Create or update PR comment
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           SUMMARY_PATH: ${{ runner.temp }}/python-pr-comment/pr-comment-summary.json
         with:


### PR DESCRIPTION
Fixes https://fivetran.atlassian.net/browse/GA-1029884

### Description of Change

- Hardened GitHub Actions workflows by making workflow permissions explicit and scoped to the jobs' actual needs.
- Reduced `pull_request_target` risk in the PR metadata workflow by using the built-in workflow token directly and avoiding checkout or execution of PR code.
- Split Python PR feedback into a read-only validation workflow plus a privileged `workflow_run` comment workflow so untrusted PR code does not share an execution context with comment-write permissions.
- Added validation around the PR comment artifact before the privileged workflow uses it: schema version, PR number, head SHA, workflow run ID, booleans, issue count bounds, and artifact size.
- Hardened README update checks by fetching exact base and head SHAs, validating SHA format before diffing, and keeping checkout credentials disabled.
- Pinned GitHub-owned actions to full commit SHAs to reduce mutable tag supply-chain risk.

### Testing

- Inspected committed workflow diff against `origin/main`.
- Reviewed GitHub Actions trust boundaries for `pull_request`, `pull_request_target`, and `workflow_run` paths.
- Verified pinned action SHAs resolve to the intended upstream `actions/*` repositories and matching release tags.
- Confirmed no committed workflow uses repository secrets, OIDC, self-hosted runners, broad artifact paths, caches, or release publishing.

### GitHub Actions Versions and Source

- actions/checkout
  Latest release: v7.0.0
  Pinned SHA: 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
  Source: https://github.com/actions/checkout/releases/tag/v7.0.0

- actions/setup-python
  Latest release: v6.2.0
  Pinned SHA: a309ff8b426b58ec0e2a45f0f869d46889d02405
  Source: https://github.com/actions/setup-python/releases/tag/v6.2.0

- actions/upload-artifact
  Latest release: v7.0.1
  Pinned SHA: 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
  Source: https://github.com/actions/upload-artifact/releases/tag/v7.0.1

- actions/download-artifact
  Latest release: v8.0.1
  Pinned SHA: 3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
  Source: https://github.com/actions/download-artifact/releases/tag/v8.0.1

- actions/github-script
  Latest release: v9.0.0
  Pinned SHA: 3a2844b7e9c422d3c10d287c895573f7108da1b3
  Source: https://github.com/actions/github-script/releases/tag/v9.0.0

Python CI Tools

- black
  Latest release: 26.5.1
  Pinned version: black==26.5.1
  Source: https://pypi.org/project/black/

- flake8
  Latest release: 7.3.0
  Pinned version: flake8==7.3.0
  Source: https://pypi.org/project/flake8/