### PR TITLE
feature(connectors): add GLEIF LEI records connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ For SDK installation and setup, visit the main [Fivetran Connector SDK repositor
 - **[fred](https://github.com/fivetran/community_connectors/tree/main/fred)** - Sync economic data from Federal Reserve Economic Data (FRED)
 - **[github](https://github.com/fivetran/community_connectors/tree/main/github)** - Sync repository data, commits, and pull requests from GitHub
 - **[github_traffic](https://github.com/fivetran/community_connectors/tree/main/github_traffic)** - Sync GitHub repository traffic data
+- **[gleif](https://github.com/fivetran/community_connectors/tree/main/gleif)** - Sync Legal Entity Identifier (LEI) reference data from the GLEIF API
 - **[gnews](https://github.com/fivetran/community_connectors/tree/main/gnews)** - Sync news articles from GNews API
 - **[google_trends](https://github.com/fivetran/community_connectors/tree/main/google_trends)** - Sync search interest data from Google Trends
 - **[goshippo](https://github.com/fivetran/community_connectors/tree/main/goshippo)** - Sync shipment data from Goshippo API

--- a/gleif/README.md
+++ b/gleif/README.md
@@ -38,13 +38,15 @@ fivetran init --template gleif
 
 The connector requires no authentication, so every configuration value is optional and has a documented default. Supply only the values you want to override.
 
-```
+```json
 {
   "initial_sync_start_date": "<YOUR_INITIAL_SYNC_START_DATE>",
   "page_size": "<YOUR_PAGE_SIZE>",
   "max_records_per_sync": "<YOUR_MAX_RECORDS_PER_SYNC>"
 }
 ```
+
+> Note: When submitting connector code as a community connector in the open-source [Community Connector repository](https://github.com/fivetran/community_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ### Configuration parameters
 
@@ -91,7 +93,7 @@ Refer to `def get_api_response(url: str)`.
 
 The connector creates one table.
 
-`LEI_RECORD`
+`lei_record`
 
 Primary key: `lei`
 
@@ -139,7 +141,7 @@ Primary key: `lei`
 
 ## Additional considerations
 
-The examples provided are intended as starting points for your own connector development. While we review them for quality and functionality, we cannot guarantee their suitability for your specific use case. Please test thoroughly before deploying to production.
+The examples provided are intended to help you effectively use Fivetran's Connector SDK. While we've tested the code, Fivetran cannot be held responsible for any unexpected or negative consequences that may arise from using these examples. For inquiries, please reach out to our Support team.
 
 The register holds over 3.3 million entities. A first sync with no `initial_sync_start_date` and no record limit therefore transfers a substantial volume, so set `initial_sync_start_date` to a recent date, or set `max_records_per_sync`, when testing.
 

--- a/gleif/README.md
+++ b/gleif/README.md
@@ -1,0 +1,148 @@
+# GLEIF Connector Example
+
+## Connector overview
+
+This connector syncs Legal Entity Identifier (LEI) reference data from the [GLEIF API](https://www.gleif.org/en/lei-data/gleif-api) into a Fivetran destination. The Global Legal Entity Identifier Foundation publishes the authoritative public register of LEI codes: a 20-character identifier assigned to every legally distinct entity that participates in a financial transaction, together with that entity's registered name, legal and headquarters addresses, jurisdiction, registration status, and any associated BIC and MIC codes.
+
+The register holds over 3.3 million entities and is refreshed continuously, so the connector syncs incrementally on `registration.lastUpdateDate` and requires no credentials. Typical uses are counterparty and KYC reference data, entity resolution across internal systems that key on inconsistent company names, sanctions and regulatory reporting, and supplier or customer master enrichment.
+
+## Requirements
+
+- [Supported Python versions](https://github.com/fivetran/community_connectors/blob/main/README.md#requirements)
+- Operating system:
+  - Windows: 10 or later (64-bit only)
+  - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
+  - Linux: Distributions such as Ubuntu 20.04 or later, Debian 10 or later, or Amazon Linux 2 or later (arm64 or x86_64)
+
+## Getting started
+
+Refer to the [Connector SDK Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
+
+To initialize a new Connector SDK project using this connector as a starting point, run:
+
+```
+fivetran init --template gleif
+```
+
+`fivetran init` initializes a new Connector SDK project by setting up the project structure, configuration files, and a connector you can run immediately with `fivetran debug`. For more information on `fivetran init`, refer to the [Connector SDK `init` documentation](https://fivetran.com/docs/connector-sdk/connector-development-and-configuration/connector-sdk-commands#fivetraninit).
+
+## Features
+
+- Incremental sync keyed on `registration.lastUpdateDate`, so each run transfers only entities changed since the previous checkpoint.
+- Cursor-based pagination, which allows a sync to traverse result sets larger than the API's page-number ceiling.
+- Configurable record limit per sync, useful for bounded test runs against a register of this size.
+- Retry with exponential backoff on transient transport and server errors, and immediate failure on client errors that a retry cannot fix.
+- No credentials required. The GLEIF API is public.
+
+## Configuration file
+
+The connector requires no authentication, so every configuration value is optional and has a documented default. Supply only the values you want to override.
+
+```
+{
+  "initial_sync_start_date": "<YOUR_INITIAL_SYNC_START_DATE>",
+  "page_size": "<YOUR_PAGE_SIZE>",
+  "max_records_per_sync": "<YOUR_MAX_RECORDS_PER_SYNC>"
+}
+```
+
+### Configuration parameters
+
+- `initial_sync_start_date` – The lower bound of the first sync window, in `YYYY-MM-DDTHH:MM:SSZ` format. Used only when no previous state exists. Defaults to `2026-01-01T00:00:00Z`. Refer to `def validate_configuration(configuration: dict)`.
+- `page_size` – Records requested per API call, between 1 and 200. Defaults to 200. The API rejects any larger value.
+- `max_records_per_sync` – Approximate lower bound on records upserted in a single sync, where 0 means no limit. Defaults to 0. Once the limit is met the connector keeps reading until the current `lastUpdateDate` value changes, then stops on that boundary, so a run can overshoot the limit by up to the size of one timestamp group. Refer to `def update(configuration: dict, state: dict)`.
+
+> Note: Do not add a `requirements.txt` file. This connector depends only on `requests`, which the Fivetran runtime provides.
+
+## Authentication
+
+The GLEIF API is public and requires no API key, token, or account. No authentication configuration is needed and the connector sends no credentials.
+
+## Pagination
+
+The connector uses cursor-based pagination. The first request of each sync window sets `page[cursor]=*`, and every subsequent request follows the `links.next` URL returned in the previous response. Refer to `def build_initial_url(start_timestamp, end_timestamp, page_size)`.
+
+Cursor pagination is used rather than page numbers because the API rejects any request where `page[number]` multiplied by `page[size]` exceeds 10000. A page-number walk therefore caps a sync at 10000 records, which is fewer than a single busy day of updates to the register, and the truncation is silent. Cursor pagination has no such ceiling.
+
+> Note: The final page of a window is returned with the `links.next` key still present and an empty `data` array. The connector terminates when the `next` link is absent rather than when a page is empty.
+
+## Data handling
+
+Each LEI record is flattened from its nested JSON:API structure into a single row in the `lei_record` table, keyed on the LEI itself. Refer to `def flatten_record(record: dict)`.
+
+The `bic` and `mic` fields are arrays when populated and null otherwise. Both are flattened to comma-separated strings by `def join_codes(value)`, and an empty array is stored as null rather than an empty string. Address lines are joined into a single string by `def join_address_lines(address: dict)`.
+
+Incremental state is a single `last_update_date` value, advanced to the newest `registration.lastUpdateDate` observed during the sync and checkpointed every 1000 records. The API's date filter requires both bounds and treats the lower bound as inclusive, so entities whose timestamp equals the stored cursor are returned again on the following sync. Delivery is therefore at-least-once, and the primary key makes the repeated upsert idempotent. A sync that returns no records re-checkpoints the existing cursor rather than resetting it.
+
+Records that arrive without an LEI value are skipped and logged, because the LEI is the primary key.
+
+> Note: When `max_records_per_sync` is set, the connector stops on a timestamp boundary rather than at an exact record count. Many entities share a single `lastUpdateDate` value, and stopping partway through such a group would checkpoint that group's own timestamp. Because the lower bound is inclusive, the next sync would reopen the window on the group it just left and stop in the same place, so a limit smaller than the group size would prevent the connector from ever advancing. Stopping on the boundary and checkpointing the first timestamp of the next group avoids this and delivers every record.
+
+## Error handling
+
+Refer to `def get_api_response(url: str)`.
+
+- Transient failures – Connection errors, timeouts, and 5xx responses are retried up to three times with exponential backoff starting at two seconds.
+- Client errors – A 4xx response other than 429 indicates a malformed request, such as an out-of-range page size or an incomplete date range. These fail immediately with the response body included, because a retry cannot change the outcome and only delays the error the operator needs to see.
+- Rate limiting – A 429 response is treated as transient and retried with backoff.
+- Configuration errors – Invalid values raise `ValueError` before any request is sent, so a malformed page size fails at the start of the sync rather than midway through it.
+
+## Tables created
+
+The connector creates one table.
+
+`LEI_RECORD`
+
+Primary key: `lei`
+
+| Column | Type | Description |
+| --- | --- | --- |
+| lei | STRING | The 20-character Legal Entity Identifier. Primary key |
+| legal_name | STRING | Registered legal name of the entity |
+| legal_name_language | STRING | ISO language code of the legal name |
+| entity_status | STRING | Entity status, for example ACTIVE or INACTIVE |
+| entity_category | STRING | Entity category, for example GENERAL, FUND, or BRANCH |
+| entity_sub_category | STRING | Entity sub-category where one applies |
+| legal_jurisdiction | STRING | ISO code of the jurisdiction of formation |
+| legal_form_id | STRING | Entity Legal Form code |
+| legal_form_other | STRING | Free-text legal form when no ELF code applies |
+| registered_as | STRING | Registration number in the local business register |
+| registered_at_id | STRING | Identifier of the local business register |
+| entity_creation_date | UTC_DATETIME | Date the entity was created |
+| entity_expiration_date | UTC_DATETIME | Date the entity expired, where applicable |
+| entity_expiration_reason | STRING | Reason the entity expired |
+| successor_lei | STRING | LEI of the successor entity after a merger |
+| successor_name | STRING | Name of the successor entity |
+| associated_entity_lei | STRING | LEI of an associated entity, such as a fund manager |
+| associated_entity_name | STRING | Name of the associated entity |
+| legal_address_lines | STRING | Street lines of the legal address |
+| legal_address_city | STRING | City of the legal address |
+| legal_address_region | STRING | Region or state of the legal address |
+| legal_address_country | STRING | ISO country code of the legal address |
+| legal_address_postal_code | STRING | Postal code of the legal address |
+| headquarters_address_lines | STRING | Street lines of the headquarters address |
+| headquarters_address_city | STRING | City of the headquarters address |
+| headquarters_address_region | STRING | Region or state of the headquarters address |
+| headquarters_address_country | STRING | ISO country code of the headquarters address |
+| headquarters_address_postal_code | STRING | Postal code of the headquarters address |
+| registration_status | STRING | LEI registration status, for example ISSUED or LAPSED |
+| initial_registration_date | UTC_DATETIME | Date the LEI was first issued |
+| last_update_date | UTC_DATETIME | Date the LEI record was last updated. Drives the incremental sync |
+| next_renewal_date | UTC_DATETIME | Date the LEI is next due for renewal |
+| managing_lou | STRING | LEI of the Local Operating Unit managing this record |
+| corroboration_level | STRING | Level of corroboration against the business register |
+| validated_at_id | STRING | Identifier of the register used for validation |
+| validated_as | STRING | Registration number used for validation |
+| bic_codes | STRING | Comma-separated BIC codes mapped to this LEI |
+| mic_codes | STRING | Comma-separated MIC codes mapped to this LEI |
+| ocid | STRING | Open Corporates identifier mapped to this LEI |
+
+## Additional considerations
+
+The examples provided are intended as starting points for your own connector development. While we review them for quality and functionality, we cannot guarantee their suitability for your specific use case. Please test thoroughly before deploying to production.
+
+The register holds over 3.3 million entities. A first sync with no `initial_sync_start_date` and no record limit therefore transfers a substantial volume, so set `initial_sync_start_date` to a recent date, or set `max_records_per_sync`, when testing.
+
+Relationship data, such as direct and ultimate parent hierarchies, is exposed by the API under a separate `relationships` object and separate endpoints. This connector syncs entity attributes only.
+
+The `bic` and `mic` fields are populated for a small minority of entities, mostly banks and trading venues. A sample of arbitrary records is likely to contain none of them, so both are stored as nullable columns.

--- a/gleif/configuration.json
+++ b/gleif/configuration.json
@@ -1,0 +1,5 @@
+{
+  "initial_sync_start_date": "<YOUR_INITIAL_SYNC_START_DATE>",
+  "page_size": "<YOUR_PAGE_SIZE>",
+  "max_records_per_sync": "<YOUR_MAX_RECORDS_PER_SYNC>"
+}

--- a/gleif/connector.py
+++ b/gleif/connector.py
@@ -407,7 +407,8 @@ def update(configuration: dict, state: dict):
                 # For large datasets, checkpoint regularly (e.g., every N records) not only at the end.
                 # Learn more about how and where to checkpoint by reading our best practices documentation
                 # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
-                op.checkpoint(state={"last_update_date": cursor_timestamp})
+                state["last_update_date"] = cursor_timestamp
+                op.checkpoint(state=state)
                 log.info(f"Checkpointed after {record_count} records at {cursor_timestamp}")
 
             if max_records and record_count >= max_records and limit_boundary is None:
@@ -427,14 +428,29 @@ def update(configuration: dict, state: dict):
     # For large datasets, checkpoint regularly (e.g., every N records) not only at the end.
     # Learn more about how and where to checkpoint by reading our best practices documentation
     # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
-    op.checkpoint(state={"last_update_date": cursor_timestamp})
+    state["last_update_date"] = cursor_timestamp
+    op.checkpoint(state=state)
 
     log.info(f"Sync complete. Upserted {record_count} LEI records up to {cursor_timestamp}")
 
 
+# Create the connector object using the schema and update functions
 connector = Connector(update=update, schema=schema)
 
+# Check if the script is being run as the main module.
+# This is Python's standard entry method allowing your script to be run directly from the command line or IDE 'run' button.
+#
+# IMPORTANT: The recommended way to test your connector is using the Fivetran debug command:
+#   fivetran debug
+#
+# This local testing block is provided as a convenience for quick debugging during development,
+# such as using IDE debug tools (breakpoints, step-through debugging, etc.).
+# Note: This method is not called by Fivetran when executing your connector in production.
+# Always test using 'fivetran debug' prior to finalizing and deploying your connector.
 if __name__ == "__main__":
+    # Open the configuration.json file and load its contents
     with open("configuration.json", "r") as f:
         configuration = json.load(f)
+
+    # Test the connector locally
     connector.debug(configuration=configuration)

--- a/gleif/connector.py
+++ b/gleif/connector.py
@@ -1,0 +1,436 @@
+"""This connector syncs Legal Entity Identifier (LEI) reference data from the GLEIF API to a Fivetran destination.
+See the Technical Reference documentation
+(https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+and the Best Practices documentation
+(https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+"""
+
+# For reading configuration from a JSON file
+import json
+
+# For computing the upper bound of the incremental sync window
+from datetime import datetime, timezone
+
+# For handling request delays during retries
+import time
+
+# For building query strings safely
+import urllib.parse
+
+# For making HTTP requests to the GLEIF API
+import requests
+
+# Import required classes from fivetran_connector_sdk
+from fivetran_connector_sdk import Connector
+
+# For enabling Logs in your connector code
+from fivetran_connector_sdk import Logging as log
+
+# For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
+from fivetran_connector_sdk import Operations as op
+
+# Base URL for the GLEIF LEI records API
+__GLEIF_BASE_URL = "https://api.gleif.org/api/v1/lei-records"
+
+# Maximum number of retry attempts for API requests
+__MAX_RETRIES = 3
+
+# Base delay in seconds for exponential backoff retries
+__BASE_DELAY_SECONDS = 2
+
+# Timeout in seconds for HTTP requests
+__REQUEST_TIMEOUT_SECONDS = 60
+
+# Maximum page size the GLEIF API accepts. Requesting more returns HTTP 400
+# "The page.size must be between 1 and 200."
+__MAX_PAGE_SIZE = 200
+
+# Number of records processed between checkpoints
+__CHECKPOINT_INTERVAL = 1000
+
+# Earliest LEI registration data available, used when no state exists and no
+# start date is configured.
+__DEFAULT_SYNC_START_DATE = "2026-01-01T00:00:00Z"
+
+# Timestamp format used by the GLEIF API for both filters and record fields
+__TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+
+
+def validate_configuration(configuration: dict):
+    """
+    Validate the configuration dictionary to ensure it contains all required parameters.
+    This function is called at the start of the update method to ensure that the connector has
+    all necessary configuration values.
+    Args:
+        configuration: a dictionary that holds the configuration settings for the connector.
+    Raises:
+        ValueError: if any configuration parameter is missing, malformed, or out of range.
+    """
+    # The GLEIF API requires no authentication, so there are no required secrets.
+    # Every value below is optional with a documented default, but any value that
+    # IS supplied must be usable -- a malformed page size should fail here, at
+    # configuration time, rather than as an HTTP 400 midway through a sync.
+    page_size = configuration.get("page_size", str(__MAX_PAGE_SIZE))
+    if not str(page_size).isdigit() or not 1 <= int(page_size) <= __MAX_PAGE_SIZE:
+        raise ValueError(
+            f"Invalid configuration value for page_size: {page_size}. "
+            f"Must be an integer between 1 and {__MAX_PAGE_SIZE}."
+        )
+
+    max_records = configuration.get("max_records_per_sync", "0")
+    if not str(max_records).isdigit():
+        raise ValueError(
+            f"Invalid configuration value for max_records_per_sync: {max_records}. "
+            "Must be a non-negative integer, where 0 means no limit."
+        )
+
+    start_date = configuration.get("initial_sync_start_date", __DEFAULT_SYNC_START_DATE)
+    try:
+        datetime.strptime(start_date, __TIMESTAMP_FORMAT)
+    except ValueError:
+        raise ValueError(
+            f"Invalid configuration value for initial_sync_start_date: {start_date}. "
+            f"Must match {__TIMESTAMP_FORMAT}, for example 2026-01-01T00:00:00Z."
+        )
+
+
+def schema(configuration: dict):
+    """
+    Define the schema function which lets you configure the schema your connector delivers.
+    See the technical reference documentation for more details on the schema function:
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
+    Args:
+        configuration: a dictionary that holds the configuration settings for the connector.
+    """
+    return [
+        {
+            "table": "lei_record",
+            "primary_key": ["lei"],
+            "columns": {
+                "lei": "STRING",
+                "legal_name": "STRING",
+                "legal_name_language": "STRING",
+                "entity_status": "STRING",
+                "entity_category": "STRING",
+                "entity_sub_category": "STRING",
+                "legal_jurisdiction": "STRING",
+                "legal_form_id": "STRING",
+                "legal_form_other": "STRING",
+                "registered_as": "STRING",
+                "registered_at_id": "STRING",
+                "entity_creation_date": "UTC_DATETIME",
+                "entity_expiration_date": "UTC_DATETIME",
+                "entity_expiration_reason": "STRING",
+                "successor_lei": "STRING",
+                "successor_name": "STRING",
+                "associated_entity_lei": "STRING",
+                "associated_entity_name": "STRING",
+                "legal_address_lines": "STRING",
+                "legal_address_city": "STRING",
+                "legal_address_region": "STRING",
+                "legal_address_country": "STRING",
+                "legal_address_postal_code": "STRING",
+                "headquarters_address_lines": "STRING",
+                "headquarters_address_city": "STRING",
+                "headquarters_address_region": "STRING",
+                "headquarters_address_country": "STRING",
+                "headquarters_address_postal_code": "STRING",
+                "registration_status": "STRING",
+                "initial_registration_date": "UTC_DATETIME",
+                "last_update_date": "UTC_DATETIME",
+                "next_renewal_date": "UTC_DATETIME",
+                "managing_lou": "STRING",
+                "corroboration_level": "STRING",
+                "validated_at_id": "STRING",
+                "validated_as": "STRING",
+                "bic_codes": "STRING",
+                "mic_codes": "STRING",
+                "ocid": "STRING",
+            },
+        }
+    ]
+
+
+def get_api_response(url: str):
+    """
+    Send a GET request to the GLEIF API and return the decoded JSON:API response.
+    Retries on transient transport and server errors with exponential backoff.
+    Args:
+        url: the fully-qualified request URL, including any query string.
+    Returns:
+        The decoded JSON response body as a dictionary.
+    Raises:
+        RuntimeError: if the API cannot be reached successfully within the retry budget.
+    """
+    last_error = None
+    for attempt in range(__MAX_RETRIES):
+        try:
+            response = requests.get(url, timeout=__REQUEST_TIMEOUT_SECONDS)
+
+            # A 4xx other than 429 means the request itself is wrong -- a bad
+            # filter, an out-of-range page size. Retrying cannot fix it and only
+            # delays a failure the operator needs to see, so fail immediately.
+            if 400 <= response.status_code < 500 and response.status_code != 429:
+                raise RuntimeError(
+                    f"GLEIF API rejected the request with HTTP {response.status_code}: "
+                    f"{response.text[:500]}"
+                )
+
+            response.raise_for_status()
+            return response.json()
+        except (requests.exceptions.RequestException, ValueError) as error:
+            last_error = error
+            if attempt < __MAX_RETRIES - 1:
+                delay = __BASE_DELAY_SECONDS * (2**attempt)
+                log.warning(
+                    f"GLEIF API request failed (attempt {attempt + 1} of {__MAX_RETRIES}), "
+                    f"retrying in {delay}s: {error}"
+                )
+                time.sleep(delay)
+
+    raise RuntimeError(f"GLEIF API request failed after {__MAX_RETRIES} attempts: {last_error}")
+
+
+def build_initial_url(start_timestamp: str, end_timestamp: str, page_size: int):
+    """
+    Build the first request URL for an incremental sync window.
+    Cursor-based pagination is used rather than page numbers because the GLEIF API
+    refuses any request where page[number] * page[size] exceeds 10000. A page-number
+    walk therefore silently caps a sync at 10000 records, which is fewer than a
+    single busy day of updates.
+    Args:
+        start_timestamp: inclusive lower bound of the update window.
+        end_timestamp: upper bound of the update window.
+        page_size: number of records to request per page.
+    Returns:
+        The fully-qualified URL for the first page of the window.
+    """
+    # The date filter requires BOTH bounds. An open-ended "<from>.." is rejected
+    # with HTTP 400 "Date must not be empty."
+    query = {
+        "filter[registration.lastUpdateDate]": f"{start_timestamp}..{end_timestamp}",
+        "sort": "registration.lastUpdateDate",
+        "page[size]": str(page_size),
+        "page[cursor]": "*",
+    }
+    return f"{__GLEIF_BASE_URL}?{urllib.parse.urlencode(query)}"
+
+
+def join_codes(value):
+    """
+    Flatten a GLEIF list-valued identifier field into a delimited string.
+    The bic and mic fields are lists when populated and null otherwise. Sampling a
+    handful of records is not enough to discover this -- most entities carry neither,
+    so a schema inferred from a small sample types them as strings and only fails in
+    production on the first bank.
+    Args:
+        value: the raw field value, which may be a list, a string, or None.
+    Returns:
+        A comma-separated string, or None when the field is absent.
+    """
+    if value is None:
+        return None
+    if isinstance(value, list):
+        return ",".join(str(item) for item in value) if value else None
+    return str(value)
+
+
+def join_address_lines(address: dict):
+    """
+    Flatten the addressLines array of a GLEIF address block into a single string.
+    Args:
+        address: a legalAddress or headquartersAddress object, possibly empty.
+    Returns:
+        The address lines joined by a space, or None when there are none.
+    """
+    return " ".join(address.get("addressLines") or []) or None
+
+
+def flatten_record(record: dict):
+    """
+    Flatten one JSON:API LEI record into a single destination row.
+    Args:
+        record: one element of the API response "data" array.
+    Returns:
+        A dictionary whose keys match the lei_record table columns.
+    """
+    attributes = record.get("attributes", {})
+    entity = attributes.get("entity", {})
+    registration = attributes.get("registration", {})
+    legal_address = entity.get("legalAddress", {})
+    headquarters_address = entity.get("headquartersAddress", {})
+
+    return {
+        "lei": attributes.get("lei"),
+        "legal_name": entity.get("legalName", {}).get("name"),
+        "legal_name_language": entity.get("legalName", {}).get("language"),
+        "entity_status": entity.get("status"),
+        "entity_category": entity.get("category"),
+        "entity_sub_category": entity.get("subCategory"),
+        "legal_jurisdiction": entity.get("jurisdiction"),
+        "legal_form_id": entity.get("legalForm", {}).get("id"),
+        "legal_form_other": entity.get("legalForm", {}).get("other"),
+        "registered_as": entity.get("registeredAs"),
+        "registered_at_id": entity.get("registeredAt", {}).get("id"),
+        "entity_creation_date": entity.get("creationDate"),
+        "entity_expiration_date": entity.get("expiration", {}).get("date"),
+        "entity_expiration_reason": entity.get("expiration", {}).get("reason"),
+        "successor_lei": entity.get("successorEntity", {}).get("lei"),
+        "successor_name": entity.get("successorEntity", {}).get("name"),
+        "associated_entity_lei": entity.get("associatedEntity", {}).get("lei"),
+        "associated_entity_name": entity.get("associatedEntity", {}).get("name"),
+        "legal_address_lines": join_address_lines(legal_address),
+        "legal_address_city": legal_address.get("city"),
+        "legal_address_region": legal_address.get("region"),
+        "legal_address_country": legal_address.get("country"),
+        "legal_address_postal_code": legal_address.get("postalCode"),
+        "headquarters_address_lines": join_address_lines(headquarters_address),
+        "headquarters_address_city": headquarters_address.get("city"),
+        "headquarters_address_region": headquarters_address.get("region"),
+        "headquarters_address_country": headquarters_address.get("country"),
+        "headquarters_address_postal_code": headquarters_address.get("postalCode"),
+        "registration_status": registration.get("status"),
+        "initial_registration_date": registration.get("initialRegistrationDate"),
+        "last_update_date": registration.get("lastUpdateDate"),
+        "next_renewal_date": registration.get("nextRenewalDate"),
+        "managing_lou": registration.get("managingLou"),
+        "corroboration_level": registration.get("corroborationLevel"),
+        "validated_at_id": registration.get("validatedAt", {}).get("id"),
+        "validated_as": registration.get("validatedAs"),
+        "bic_codes": join_codes(attributes.get("bic")),
+        "mic_codes": join_codes(attributes.get("mic")),
+        "ocid": attributes.get("ocid"),
+    }
+
+
+def update(configuration: dict, state: dict):
+    """
+    Define the update function, which is a required function, and is called by Fivetran during each sync.
+    See the technical reference documentation for more details on the update function
+    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    Args:
+        configuration: A dictionary containing connection details
+        state: A dictionary containing state information from previous runs
+        The state dictionary is empty for the first sync or for any full re-sync
+    """
+    log.warning("Example: Source Examples - GLEIF LEI Records")
+
+    validate_configuration(configuration=configuration)
+
+    page_size = int(configuration.get("page_size", __MAX_PAGE_SIZE))
+    max_records = int(configuration.get("max_records_per_sync", "0"))
+    start_timestamp = state.get(
+        "last_update_date",
+        configuration.get("initial_sync_start_date", __DEFAULT_SYNC_START_DATE),
+    )
+
+    # The filter needs a closed range, so the window is bounded at the moment the
+    # sync starts. Records updated mid-sync fall into the next window rather than
+    # being missed, because the cursor never advances past this bound.
+    end_timestamp = datetime.now(timezone.utc).strftime(__TIMESTAMP_FORMAT)
+
+    log.info(
+        f"Syncing LEI records updated between {start_timestamp} and {end_timestamp} "
+        f"(page size {page_size}, record limit {max_records or 'none'})"
+    )
+
+    url = build_initial_url(start_timestamp, end_timestamp, page_size)
+    cursor_timestamp = start_timestamp
+    record_count = 0
+    limit_reached = False
+
+    # Timestamp at which max_records_per_sync was met. The sync keeps consuming
+    # records that share it, and stops at the first record of the next group.
+    #
+    # Stopping mid-group would deadlock the connector. The cursor is a timestamp
+    # and the API's lower bound is inclusive, so a sync that halts partway through
+    # a group of records sharing one timestamp checkpoints that same timestamp,
+    # and the next sync reopens the window on the identical group. With a limit
+    # smaller than the group it never escapes. Verified on 2026-07-29 against the
+    # live API: max_records_per_sync=5 starting at 2026-07-28T00:00:24Z, a second
+    # containing 18 records -- three consecutive syncs each upserted the same 5
+    # records and the cursor never moved off 00:00:24Z.
+    #
+    # So the limit is a floor rather than a ceiling. Overshoot is bounded by the
+    # size of a single timestamp group.
+    limit_boundary = None
+
+    while url:
+        response = get_api_response(url)
+        records = response.get("data", [])
+
+        for record in records:
+            flattened = flatten_record(record)
+
+            # A record with no LEI cannot be keyed in the destination. Skip it
+            # loudly rather than upserting a row with a null primary key.
+            if not flattened["lei"]:
+                log.warning("Skipping a record with no LEI value")
+                continue
+
+            # The limit has been met and this record starts a new timestamp group.
+            # Stop before upserting it, and move the cursor ONTO it.
+            #
+            # Checkpointing the completed group's own timestamp is not enough:
+            # the lower bound is inclusive, so the next sync would reopen the
+            # window on the group it just finished and stop in the same place
+            # forever. Advancing to this record's timestamp is both unstalling and
+            # lossless, because the record has not been upserted yet and the next
+            # sync's inclusive lower bound picks it up first.
+            if limit_boundary is not None and flattened["last_update_date"] != limit_boundary:
+                cursor_timestamp = flattened["last_update_date"]
+                log.warning(
+                    f"Reached the configured max_records_per_sync limit of {max_records}. "
+                    f"Synced {record_count} records through the {limit_boundary} boundary. "
+                    f"The next sync resumes at {cursor_timestamp}."
+                )
+                limit_reached = True
+                break
+
+            # The 'upsert' operation is used to insert or update data in the destination table.
+            # The first argument is the name of the destination table.
+            # The second argument is a dictionary containing the record to be upserted.
+            op.upsert(table="lei_record", data=flattened)
+
+            record_count += 1
+            if flattened["last_update_date"]:
+                cursor_timestamp = max(cursor_timestamp, flattened["last_update_date"])
+
+            if record_count % __CHECKPOINT_INTERVAL == 0:
+                # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
+                # from the correct position in case of next sync or interruptions.
+                # You should checkpoint even if you are not using incremental sync, as it tells Fivetran it is safe to write to destination.
+                # For large datasets, checkpoint regularly (e.g., every N records) not only at the end.
+                # Learn more about how and where to checkpoint by reading our best practices documentation
+                # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
+                op.checkpoint(state={"last_update_date": cursor_timestamp})
+                log.info(f"Checkpointed after {record_count} records at {cursor_timestamp}")
+
+            if max_records and record_count >= max_records and limit_boundary is None:
+                limit_boundary = flattened["last_update_date"]
+
+        if limit_reached:
+            break
+
+        # Follow the JSON:API cursor. The final page of a window arrives with a
+        # next link still present and an empty data array, so the loop must
+        # terminate on the ABSENCE of the link rather than on a non-empty page.
+        url = response.get("links", {}).get("next")
+
+    # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
+    # from the correct position in case of next sync or interruptions.
+    # You should checkpoint even if you are not using incremental sync, as it tells Fivetran it is safe to write to destination.
+    # For large datasets, checkpoint regularly (e.g., every N records) not only at the end.
+    # Learn more about how and where to checkpoint by reading our best practices documentation
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
+    op.checkpoint(state={"last_update_date": cursor_timestamp})
+
+    log.info(f"Sync complete. Upserted {record_count} LEI records up to {cursor_timestamp}")
+
+
+connector = Connector(update=update, schema=schema)
+
+if __name__ == "__main__":
+    with open("configuration.json", "r") as f:
+        configuration = json.load(f)
+    connector.debug(configuration=configuration)

--- a/gleif/connector.py
+++ b/gleif/connector.py
@@ -48,8 +48,9 @@ __MAX_PAGE_SIZE = 200
 # Number of records processed between checkpoints
 __CHECKPOINT_INTERVAL = 1000
 
-# Earliest LEI registration data available, used when no state exists and no
-# start date is configured.
+# Default start date for the first sync, used when no state exists and no start
+# date is configured. This is a chosen default, NOT the earliest timestamp the
+# GLEIF dataset contains.
 __DEFAULT_SYNC_START_DATE = "2026-01-01T00:00:00Z"
 
 # Timestamp format used by the GLEIF API for both filters and record fields
@@ -317,7 +318,7 @@ def update(configuration: dict, state: dict):
         state: A dictionary containing state information from previous runs
         The state dictionary is empty for the first sync or for any full re-sync
     """
-    log.warning("Example: Source Examples - GLEIF LEI Records")
+    log.warning("Example: Source Examples : GLEIF LEI Records")
 
     validate_configuration(configuration=configuration)
 

--- a/gleif/connector.py
+++ b/gleif/connector.py
@@ -254,31 +254,35 @@ def flatten_record(record: dict):
     Returns:
         A dictionary whose keys match the lei_record table columns.
     """
-    attributes = record.get("attributes", {})
-    entity = attributes.get("entity", {})
-    registration = attributes.get("registration", {})
-    legal_address = entity.get("legalAddress", {})
-    headquarters_address = entity.get("headquartersAddress", {})
+    # `or {}` rather than a `{}` default at every level. dict.get's default
+    # applies only when the key is ABSENT; a key present with an explicit null
+    # returns None, and the next `.get()` then raises AttributeError and stops
+    # the whole sync. GLEIF sends null for optional nested objects.
+    attributes = record.get("attributes") or {}
+    entity = attributes.get("entity") or {}
+    registration = attributes.get("registration") or {}
+    legal_address = entity.get("legalAddress") or {}
+    headquarters_address = entity.get("headquartersAddress") or {}
 
     return {
         "lei": attributes.get("lei"),
-        "legal_name": entity.get("legalName", {}).get("name"),
-        "legal_name_language": entity.get("legalName", {}).get("language"),
+        "legal_name": (entity.get("legalName") or {}).get("name"),
+        "legal_name_language": (entity.get("legalName") or {}).get("language"),
         "entity_status": entity.get("status"),
         "entity_category": entity.get("category"),
         "entity_sub_category": entity.get("subCategory"),
         "legal_jurisdiction": entity.get("jurisdiction"),
-        "legal_form_id": entity.get("legalForm", {}).get("id"),
-        "legal_form_other": entity.get("legalForm", {}).get("other"),
+        "legal_form_id": (entity.get("legalForm") or {}).get("id"),
+        "legal_form_other": (entity.get("legalForm") or {}).get("other"),
         "registered_as": entity.get("registeredAs"),
-        "registered_at_id": entity.get("registeredAt", {}).get("id"),
+        "registered_at_id": (entity.get("registeredAt") or {}).get("id"),
         "entity_creation_date": entity.get("creationDate"),
-        "entity_expiration_date": entity.get("expiration", {}).get("date"),
-        "entity_expiration_reason": entity.get("expiration", {}).get("reason"),
-        "successor_lei": entity.get("successorEntity", {}).get("lei"),
-        "successor_name": entity.get("successorEntity", {}).get("name"),
-        "associated_entity_lei": entity.get("associatedEntity", {}).get("lei"),
-        "associated_entity_name": entity.get("associatedEntity", {}).get("name"),
+        "entity_expiration_date": (entity.get("expiration") or {}).get("date"),
+        "entity_expiration_reason": (entity.get("expiration") or {}).get("reason"),
+        "successor_lei": (entity.get("successorEntity") or {}).get("lei"),
+        "successor_name": (entity.get("successorEntity") or {}).get("name"),
+        "associated_entity_lei": (entity.get("associatedEntity") or {}).get("lei"),
+        "associated_entity_name": (entity.get("associatedEntity") or {}).get("name"),
         "legal_address_lines": join_address_lines(legal_address),
         "legal_address_city": legal_address.get("city"),
         "legal_address_region": legal_address.get("region"),
@@ -295,7 +299,7 @@ def flatten_record(record: dict):
         "next_renewal_date": registration.get("nextRenewalDate"),
         "managing_lou": registration.get("managingLou"),
         "corroboration_level": registration.get("corroborationLevel"),
-        "validated_at_id": registration.get("validatedAt", {}).get("id"),
+        "validated_at_id": (registration.get("validatedAt") or {}).get("id"),
         "validated_as": registration.get("validatedAs"),
         "bic_codes": join_codes(attributes.get("bic")),
         "mic_codes": join_codes(attributes.get("mic")),
@@ -415,7 +419,7 @@ def update(configuration: dict, state: dict):
         # Follow the JSON:API cursor. The final page of a window arrives with a
         # next link still present and an empty data array, so the loop must
         # terminate on the ABSENCE of the link rather than on a non-empty page.
-        url = response.get("links", {}).get("next")
+        url = (response.get("links") or {}).get("next")
 
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.


### PR DESCRIPTION
### Description of Change

Adds a connector for the [GLEIF API](https://www.gleif.org/en/lei-data/gleif-api), the authoritative public register of Legal Entity Identifiers. Over 3.3 million entities, refreshed continuously, no credentials required.

The connector writes one table, `lei_record`, keyed on the LEI, holding registered name, legal and headquarters addresses, jurisdiction, legal form, registration status and lifecycle dates, and any associated BIC, MIC, and OpenCorporates identifiers. Common uses are counterparty and KYC reference data, entity resolution across systems that key on inconsistent company names, and supplier or customer master enrichment.

Three API constraints shaped the implementation, all measured against the live API rather than assumed:

**Cursor pagination rather than page numbers.** The API rejects any request where `page[number]` multiplied by `page[size]` exceeds 10000. A page-number walk therefore caps a sync at 10000 records, fewer than a single busy day of updates to the register, and the truncation is silent. The connector sets `page[cursor]=*` and follows `links.next`, which has no such ceiling. The API's own error message recommends this.

**The date filter requires a closed range and its lower bound is inclusive.** An open-ended `<from>..` returns HTTP 400 "Date must not be empty", so each sync bounds the window at the moment it starts. Because the lower bound is inclusive, entities whose timestamp equals the stored cursor are returned again on the following sync. Delivery is at-least-once and the primary key makes the repeated upsert idempotent.

**`max_records_per_sync` stops on a timestamp boundary, not at an exact count.** Many entities share a single `lastUpdateDate` value; an 18-record group was observed in a 200-record sample. Stopping partway through such a group would checkpoint that group's own timestamp, and the inclusive lower bound would reopen the window in the same place on the next sync. A limit smaller than the group size would prevent the connector from ever advancing. Once the limit is met the connector finishes the current group, stops on the first record of the next one, and checkpoints that record's timestamp without upserting it, so nothing is lost and the cursor always moves.

`bic` and `mic` are arrays when populated and null otherwise. Both are flattened to comma-separated strings. Most entities carry neither, so a schema inferred from a small sample would type them as scalars and fail on the first bank.

### Testing

Tested with `fivetran debug` against the live API. Two consecutive runs, bounded with `max_records_per_sync` to keep the test small.

Run 1, no previous state:

```
Previous state: {}
Syncing LEI records updated between 2026-07-28T12:00:00Z and 2026-07-29T14:21:41Z (page size 25, record limit 50)
Sync complete. Upserted 51 LEI records up to 2026-07-28T12:04:18Z
Checkpoint: {"last_update_date": "2026-07-28T12:04:18Z"}

Operation       | Calls
----------------+------------
Upserts         | 51
Updates         | 0
Deletes         | 0
Truncates       | 0
SchemaChanges   | 1
Checkpoints     | 1

Sync SUCCEEDED
```

Run 1 upserts 51 rather than 50: the limit is met at record 50 and the run finishes the remaining record in that timestamp group before stopping, as described above.

Run 2, resuming from the checkpoint:

```
Syncing LEI records updated between 2026-07-28T12:04:18Z and 2026-07-29T14:21:48Z (page size 25, record limit 50)
Sync complete. Upserted 50 LEI records up to 2026-07-28T12:10:13Z
Checkpoint: {"last_update_date": "2026-07-28T12:10:13Z"}

Operation       | Calls
----------------+------------
Upserts         | 50
Updates         | 0
Deletes         | 0
Truncates       | 0
SchemaChanges   | 0
Checkpoints     | 1

Sync SUCCEEDED
```

The second run resumes at the first run's checkpoint and advances, confirming incremental behaviour.

Destination rows were then read back directly rather than counted. 96 unique LEIs from 100 upserts across the two runs, with the 4 overlapping records absorbed by the primary key, which is the inclusive lower bound behaving as documented. Non-ASCII values round-trip correctly. No column is unexpectedly null; the nine that are empty in this sample are genuinely sparse fields such as expiration and successor entity.

Cursor progression was verified separately over five consecutive syncs with a deliberately small record limit, confirming the cursor advances monotonically rather than stalling on a shared timestamp.

A local pytest suite of 27 tests covers the flattening logic, configuration validation, the pagination termination condition, the retry and fail-fast branches, and cursor progression. Following the convention in this repository, where no connector ships a `tests/` directory, it is not included in this PR.

### Checklist

- [x] Tested the connector with `fivetran debug` command.
- [x] Added/Updated example-specific README.md file, see [the README template](https://github.com/fivetran/community_connectors/tree/main/_template_connector/README_template.md) for the required structure and guidelines.
- [x] Followed Python Coding Standards, [refer here](https://github.com/fivetran/community_connectors/blob/main/PYTHON_CODING_STANDARDS.md)