### PR TITLE
feat: add beehiiv API connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ For SDK installation and setup, visit the main [Fivetran Connector SDK repositor
 
 - **[amazon_video_central](https://github.com/fivetran/community_connectors/tree/main/amazon_video_central)** - Sync report data from Amazon Video Central API
 - **[awardco](https://github.com/fivetran/community_connectors/tree/main/awardco)** - Sync data from Awardco rewards platform
+- **[beehiiv](https://github.com/fivetran/community_connectors/tree/main/beehiiv)** - Sync newsletter data from the beehiiv API including publications, subscriptions, posts, email blasts, automations, and engagement metrics
 - **[betterstack](https://github.com/fivetran/community_connectors/tree/main/betterstack)** - Sync uptime monitoring data from Better Stack
 - **[callminer](https://github.com/fivetran/fivetran_csdk_connectors/tree/main/callminer)** - Sync CallMiner Bulk Export data using OAuth2 authentication, export job polling, archive extraction, and per-data-type incremental state tracking
 - **[checkly](https://github.com/fivetran/community_connectors/tree/main/checkly)** - Sync monitoring check data and analytics from Checkly

--- a/beehiiv/README.md
+++ b/beehiiv/README.md
@@ -1,4 +1,4 @@
-# beehiiv Connector Example
+# Beehiiv Connector Example
 
 ## Connector overview
 This connector integrates with the [beehiiv API](https://developers.beehiiv.com/) to synchronize newsletter data into your destination. It fetches publications, subscriptions, posts, email blasts, automations, engagement metrics, and other newsletter management data from a single beehiiv publication.
@@ -55,16 +55,16 @@ Configuration parameters:
 When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
-The `requirements.txt` file specifies `requests` as the only external dependency.
+This connector uses only the `requests` library, which is pre-installed in the Fivetran environment, so no `requirements.txt` file is needed.
 
 > Note: The `fivetran_connector_sdk:latest` and `requests:latest` packages are pre-installed in the Fivetran environment. To avoid dependency conflicts, do not declare them in your `requirements.txt`.
 
 ## Authentication
-This connector uses API key authentication with bearer tokens. The API key is passed in the `Authorization` header as `Bearer <api_key>`.
+This connector authenticates with the beehiiv API using a bearer token. Every request includes an `Authorization` header whose value is the word `Bearer`, a space, and your beehiiv API key (for example, `Authorization: Bearer YOUR_API_KEY`).
 
 To obtain your beehiiv API key:
 1. Log in to your [beehiiv Dashboard](https://app.beehiiv.com/).
-2. Navigate to **Settings** > **Integrations** > **API**.
+2. Navigate to **Settings**, then **Integrations**, then **API**.
 3. Generate a new API key with the required scopes: `publications:read`, `posts:read`, `automations:read`, `condition_sets:read`.
 4. Copy the key and add it to your `configuration.json` file.
 

--- a/beehiiv/README.md
+++ b/beehiiv/README.md
@@ -51,13 +51,12 @@ Configuration parameters:
 - `api_key` (required) - your beehiiv API key (Bearer token). Required scopes: `publications:read`, `posts:read`, `automations:read`, `condition_sets:read`.
 - `publication_id` (required) - the prefixed publication ID (e.g., `pub_xxx`). All endpoints except publications are scoped to this publication. Create a separate Fivetran connection for each publication.
 
-> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_connector_sdk/tree/main/connectors) or enhancing an [example](https://github.com/fivetran/fivetran_connector_sdk/tree/main/examples) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_connector_sdk/tree/main), ensure the `configuration.json` file has placeholder values.
-When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+> Note: When submitting connector code as a community connector in the open-source [Community Connector repository](https://github.com/fivetran/community_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
 This connector uses only the `requests` library, which is pre-installed in the Fivetran environment, so no `requirements.txt` file is needed.
 
-> Note: The `fivetran_connector_sdk:latest` and `requests:latest` packages are pre-installed in the Fivetran environment. To avoid dependency conflicts, do not declare them in your `requirements.txt`.
+> Note: [Some packages](https://fivetran.com/docs/connector-sdk/technical-reference#preinstalledpackages) are pre-installed in the Connector SDK runtime environment. To avoid dependency conflicts, do not declare them in your `requirements.txt`.
 
 ## Authentication
 This connector authenticates with the beehiiv API using a bearer token. Every request includes an `Authorization` header whose value is the word `Bearer`, a space, and your beehiiv API key (for example, `Authorization: Bearer YOUR_API_KEY`).

--- a/beehiiv/README.md
+++ b/beehiiv/README.md
@@ -1,0 +1,134 @@
+# beehiiv Connector Example
+
+## Connector overview
+This connector integrates with the [beehiiv API](https://developers.beehiiv.com/) to synchronize newsletter data into your destination. It fetches publications, subscriptions, posts, email blasts, automations, engagement metrics, and other newsletter management data from a single beehiiv publication.
+
+The connector supports incremental sync for high-volume tables (subscriptions, posts, email blasts, engagements) using timestamp-based cursors, and full sync for low-volume reference tables. It handles both page-number and cursor-based pagination patterns used across the beehiiv API.
+
+## Accreditation
+
+This example was contributed by [AngelList](https://www.angellist.com/).
+
+## Requirements
+- [Supported Python versions](https://github.com/fivetran/community_connectors/blob/main/README.md#requirements)
+- Operating system:
+  - Windows: 10 or later (64-bit only)
+  - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
+  - Linux: Distributions such as Ubuntu 20.04 or later, Debian 10 or later, or Amazon Linux 2 or later (arm64 or x86_64)
+
+## Getting started
+Refer to the [Connector SDK Setup Guide](https://fivetran.com/docs/connector-sdk/setup-guide) to get started.
+
+To initialize a new Connector SDK project using this connector as a starting point, run:
+
+```bash
+fivetran init --template beehiiv
+```
+`fivetran init` initializes a new Connector SDK project by setting up the project structure, configuration files, and a connector you can run immediately with `fivetran debug`. For more information on `fivetran init`, refer to the [Connector SDK `init` documentation](https://fivetran.com/docs/connector-sdk/connector-development-and-configuration/connector-sdk-commands#fivetraninit).
+
+> Note: Ensure you have updated the `configuration.json` file with the necessary parameters before running `fivetran debug`. See the [Configuration file](#configuration-file) section for details on the required configuration parameters.
+
+## Features
+- Syncs 17 tables covering the full beehiiv API surface (publications, subscriptions, posts, email blasts, automations, journeys, authors, segments, custom fields, newsletter lists, tiers, referral program, polls, condition sets, post templates, engagements, advertisement opportunities)
+- Incremental sync for high-volume tables using `created` timestamp cursors
+- Date-range based incremental sync for daily engagement metrics
+- Both page-number and cursor-based pagination support
+- Nested object handling via automation journey sub-resource iteration
+- VARIANT columns for nested JSON objects (stats, custom fields, tags, etc.)
+- Retry logic with exponential backoff for rate-limited and server error responses
+- Periodic checkpointing for high-volume tables to enable resumption on interruption
+
+## Configuration file
+
+```json
+{
+  "api_key": "<YOUR_BEEHIIV_API_KEY>",
+  "publication_id": "<YOUR_BEEHIIV_PUBLICATION_ID>"
+}
+```
+
+Configuration parameters:
+- `api_key` (required) - your beehiiv API key (Bearer token). Required scopes: `publications:read`, `posts:read`, `automations:read`, `condition_sets:read`.
+- `publication_id` (required) - the prefixed publication ID (e.g., `pub_xxx`). All endpoints except publications are scoped to this publication. Create a separate Fivetran connection for each publication.
+
+> Note: When submitting connector code as a [Community Connector](https://github.com/fivetran/fivetran_connector_sdk/tree/main/connectors) or enhancing an [example](https://github.com/fivetran/fivetran_connector_sdk/tree/main/examples) in the open-source [Connector SDK repository](https://github.com/fivetran/fivetran_connector_sdk/tree/main), ensure the `configuration.json` file has placeholder values.
+When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+
+## Requirements file
+The `requirements.txt` file specifies `requests` as the only external dependency.
+
+> Note: The `fivetran_connector_sdk:latest` and `requests:latest` packages are pre-installed in the Fivetran environment. To avoid dependency conflicts, do not declare them in your `requirements.txt`.
+
+## Authentication
+This connector uses API key authentication with bearer tokens. The API key is passed in the `Authorization` header as `Bearer <api_key>`.
+
+To obtain your beehiiv API key:
+1. Log in to your [beehiiv Dashboard](https://app.beehiiv.com/).
+2. Navigate to **Settings** > **Integrations** > **API**.
+3. Generate a new API key with the required scopes: `publications:read`, `posts:read`, `automations:read`, `condition_sets:read`.
+4. Copy the key and add it to your `configuration.json` file.
+
+## Pagination
+
+The connector implements two pagination patterns used across the beehiiv API:
+
+Page-number pagination:
+- Used by most endpoints (posts, email blasts, automations, authors, segments, etc.)
+- Fetches pages sequentially with `page` and `limit` parameters (100 records per page)
+- Continues until `page >= total_pages` from the response
+- Refer to `paginate_page_number()` in `connector.py`
+
+Cursor-based pagination:
+- Used by subscriptions, polls, and condition sets endpoints
+- Passes `cursor` from the `next_cursor` field in each response
+- Continues until `has_more` is false
+- Refer to `paginate_cursor()` in `connector.py`
+
+## Data handling
+
+Incremental sync:
+- Subscriptions, posts, and email blasts track a `created` timestamp cursor in the connector state, fetching only records created after the last sync
+- Engagements use a date-range approach, fetching from the last synced date to today in chunks of up to 31 days (the API maximum)
+- Refer to `sync_subscriptions()`, `sync_posts()`, `sync_email_blasts()`, and `sync_engagements()` in `connector.py`
+
+Full sync:
+- Low-volume reference tables (authors, segments, custom fields, tiers, etc.) are fully replaced each sync
+- Refer to `sync_simple_page_table()` and `sync_simple_cursor_table()` in `connector.py`
+
+Nested data:
+- Nested JSON objects and arrays (stats, custom fields, tags, poll choices, milestones, prices) are passed through as VARIANT columns for downstream extraction
+- HTML content fields are explicitly excluded from post records to avoid syncing large blobs
+- Automation journeys are a nested sub-resource requiring iteration over each parent automation
+- Refer to `sync_automations_and_journeys()` and `sync_posts()` in `connector.py`
+
+## Error handling
+- All API requests include retry logic with exponential backoff (1s initial, 60s max, 5 retries) for rate-limited (429) and server error (5xx) responses
+- Request timeouts are set to 30 seconds
+- Optional endpoints (referral program, advertisement opportunities) log warnings and continue if unavailable
+- Configuration is validated at the start of each sync to fail fast on missing parameters
+- Refer to `make_api_request()` and `validate_configuration()` in `connector.py`
+
+## Tables created
+
+| Table | Primary key | Sync strategy | Description |
+|---|---|---|---|
+| `publications` | `id` | Full | Publication metadata and stats |
+| `subscriptions` | `id` | Incremental (created) | Subscriber records with stats, custom fields, tags |
+| `posts` | `id` | Incremental (created) | Newsletter posts with stats (content excluded) |
+| `email_blasts` | `id` | Incremental (created) | Email blast campaigns with stats |
+| `automations` | `id` | Full | Automation definitions with stats |
+| `automation_journeys` | `id` | Full | Individual automation journey records |
+| `authors` | `id` | Full | Publication authors |
+| `segments` | `id` | Full | Subscriber segments with stats |
+| `custom_fields` | `id` | Full | Custom field definitions |
+| `newsletter_lists` | `id` | Full | Newsletter list definitions |
+| `tiers` | `id` | Full | Subscription tiers with prices |
+| `referral_program` | `id` | Full | Referral program config and milestones |
+| `polls` | `id` | Full | Polls with choices and stats |
+| `condition_sets` | `id` | Full | Dynamic content condition sets |
+| `post_templates` | `id` | Full | Post template definitions |
+| `engagements` | `date` | Incremental (date) | Daily engagement metrics (aggregated across email types) |
+| `advertisement_opportunities` | `id` | Full | Accepted ad opportunities |
+
+## Additional considerations
+The examples provided are intended to help you effectively use Fivetran's Connector SDK. While we've tested the code, Fivetran cannot be held responsible for any unexpected or negative consequences that may arise from using these examples. For inquiries, please reach out to our Support team.

--- a/beehiiv/configuration.json
+++ b/beehiiv/configuration.json
@@ -1,0 +1,4 @@
+{
+  "api_key": "<YOUR_BEEHIIV_API_KEY>",
+  "publication_id": "<YOUR_BEEHIIV_PUBLICATION_ID>"
+}

--- a/beehiiv/connector.py
+++ b/beehiiv/connector.py
@@ -1,0 +1,710 @@
+"""beehiiv API Connector for Fivetran Connector SDK.
+This connector syncs newsletter data from the beehiiv API into your destination.
+It supports incremental sync for high-volume tables and full sync for low-volume reference data.
+See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
+and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+"""
+
+# For adding delay between retries
+import time
+
+# Import required classes from fivetran_connector_sdk
+from fivetran_connector_sdk import Connector
+
+# For enabling Logs in your connector code
+from fivetran_connector_sdk import Logging as log
+
+# For supporting Data operations like upsert(), update(), delete() and checkpoint()
+from fivetran_connector_sdk import Operations as op
+
+# For making HTTP requests to the beehiiv API
+import requests
+
+# For date manipulation in engagement date-range queries
+from datetime import datetime, timedelta, timezone
+
+# Constants for API configuration
+__API_BASE_URL = "https://api.beehiiv.com/v2"
+__PAGE_LIMIT = 100  # Maximum records per API request
+__MAX_RETRIES = 5  # Maximum number of retry attempts for rate-limited or failed requests
+__INITIAL_BACKOFF_SEC = 1  # Initial backoff delay in seconds for retries
+__MAX_BACKOFF_SEC = 60  # Maximum backoff delay in seconds
+__REQUEST_TIMEOUT_SEC = 30  # Timeout for each API request in seconds
+__CHECKPOINT_INTERVAL = 1000  # Checkpoint state after every N records for high-volume tables
+__ENGAGEMENTS_LOOKBACK_DAYS = 90  # Default lookback window for first engagement sync
+__ENGAGEMENTS_MAX_DAYS_PER_REQUEST = 31  # Maximum days per engagement API request
+__RATE_LIMIT_STATUS_CODE = 429  # HTTP status code for rate limiting
+__SERVER_ERROR_MIN_STATUS = 500  # Minimum HTTP status code for server errors
+
+
+def validate_configuration(configuration: dict):
+    """Validate the configuration dictionary to ensure it contains all required parameters.
+
+    Args:
+        configuration: A dictionary that holds the configuration settings for the connector.
+
+    Raises:
+        ValueError: If any required configuration parameter is missing.
+    """
+    required_configs = ["api_key", "publication_id"]
+    for key in required_configs:
+        if key not in configuration:
+            raise ValueError(f"Missing required configuration value: {key}")
+
+
+def schema(configuration: dict):
+    """Define the schema for all destination tables.
+
+    All tables use 'id' as the primary key (STRING) except engagements which uses 'date'.
+    Nested objects are stored as VARIANT columns
+    (the SDK infers JSON columns automatically when dicts/lists are upserted).
+
+    See the technical reference documentation for more details on the schema function:
+    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+
+    Args:
+        configuration: A dictionary that holds the configuration settings for the connector.
+    """
+    return [
+        {"table": "publications", "primary_key": ["id"]},
+        {"table": "subscriptions", "primary_key": ["id"]},
+        {"table": "posts", "primary_key": ["id"]},
+        {"table": "email_blasts", "primary_key": ["id"]},
+        {"table": "automations", "primary_key": ["id"]},
+        {"table": "automation_journeys", "primary_key": ["id"]},
+        {"table": "authors", "primary_key": ["id"]},
+        {"table": "segments", "primary_key": ["id"]},
+        {"table": "custom_fields", "primary_key": ["id"]},
+        {"table": "newsletter_lists", "primary_key": ["id"]},
+        {"table": "tiers", "primary_key": ["id"]},
+        {"table": "referral_program", "primary_key": ["id"]},
+        {"table": "polls", "primary_key": ["id"]},
+        {"table": "condition_sets", "primary_key": ["id"]},
+        {"table": "post_templates", "primary_key": ["id"]},
+        {"table": "engagements", "primary_key": ["date"]},
+        {"table": "advertisement_opportunities", "primary_key": ["id"]},
+    ]
+
+
+def update(configuration: dict, state: dict):
+    """Sync data from the beehiiv API into all destination tables.
+
+    This function is called by Fivetran during each sync. It handles both incremental
+    and full-sync tables, checkpointing state after each table completes.
+
+    See the technical reference documentation for more details on the update function:
+    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+
+    Args:
+        configuration: A dictionary containing connection details (api_key, publication_id).
+        state: A dictionary containing state information from previous runs.
+               The state dictionary is empty for the first sync or for any full re-sync.
+    """
+    log.info("beehiiv connector: starting sync")
+
+    validate_configuration(configuration)
+
+    api_key = configuration["api_key"]
+    publication_id = configuration["publication_id"]
+
+    # Sync each table, updating state progressively
+    state = sync_publications(api_key, publication_id, state)
+    state = sync_subscriptions(api_key, publication_id, state)
+    state = sync_posts(api_key, publication_id, state)
+    state = sync_email_blasts(api_key, publication_id, state)
+    state = sync_automations_and_journeys(api_key, publication_id, state)
+    state = sync_simple_page_table(api_key, publication_id, state, "authors", "/authors")
+    state = sync_simple_page_table(
+        api_key, publication_id, state, "segments", "/segments", expand=["stats"]
+    )
+    state = sync_simple_page_table(
+        api_key, publication_id, state, "custom_fields", "/custom_fields"
+    )
+    state = sync_simple_page_table(
+        api_key, publication_id, state, "newsletter_lists", "/newsletter_lists"
+    )
+    state = sync_simple_page_table(
+        api_key, publication_id, state, "tiers", "/tiers", expand=["stats", "prices"]
+    )
+    state = sync_referral_program(api_key, publication_id, state)
+    state = sync_simple_cursor_table(
+        api_key, publication_id, state, "polls", "/polls", expand=["stats"]
+    )
+    state = sync_simple_cursor_table(
+        api_key, publication_id, state, "condition_sets", "/condition_sets"
+    )
+    state = sync_simple_page_table(
+        api_key, publication_id, state, "post_templates", "/post_templates"
+    )
+    state = sync_engagements(api_key, publication_id, state)
+    state = sync_advertisement_opportunities(api_key, publication_id, state)
+
+    log.info("beehiiv connector: sync completed")
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers
+# ---------------------------------------------------------------------------
+
+
+def make_api_request(url, api_key, params=None):
+    """Make an authenticated GET request to the beehiiv API with retry logic.
+
+    Implements exponential backoff for rate-limited (429) and server error (5xx) responses.
+
+    Args:
+        url: The full API endpoint URL.
+        api_key: The beehiiv API bearer token.
+        params: Optional dictionary of query parameters.
+
+    Returns:
+        The parsed JSON response body as a dictionary.
+
+    Raises:
+        RuntimeError: If the request fails after all retries.
+    """
+    headers = {"Authorization": f"Bearer {api_key}"}
+    backoff = __INITIAL_BACKOFF_SEC
+
+    for attempt in range(1, __MAX_RETRIES + 1):
+        try:
+            response = requests.get(
+                url, headers=headers, params=params, timeout=__REQUEST_TIMEOUT_SEC
+            )
+
+            if response.status_code == __RATE_LIMIT_STATUS_CODE:
+                if attempt == __MAX_RETRIES:
+                    raise RuntimeError(f"Rate limited after {__MAX_RETRIES} retries: {url}")
+                log.warning(
+                    f"Rate limited on {url}. Retrying in {backoff}s "
+                    f"(attempt {attempt}/{__MAX_RETRIES})"
+                )
+                time.sleep(backoff)
+                backoff = min(backoff * 2, __MAX_BACKOFF_SEC)
+                continue
+
+            if __SERVER_ERROR_MIN_STATUS <= response.status_code < 600:
+                if attempt == __MAX_RETRIES:
+                    raise RuntimeError(
+                        f"Server error {response.status_code} after {__MAX_RETRIES} "
+                        f"retries: {url}"
+                    )
+                log.warning(
+                    f"Server error {response.status_code} on {url}. "
+                    f"Retrying in {backoff}s (attempt {attempt}/{__MAX_RETRIES})"
+                )
+                time.sleep(backoff)
+                backoff = min(backoff * 2, __MAX_BACKOFF_SEC)
+                continue
+
+            response.raise_for_status()
+            return response.json()
+
+        except (requests.exceptions.Timeout, requests.exceptions.ConnectionError) as e:
+            if attempt == __MAX_RETRIES:
+                raise RuntimeError(f"Request failed after {__MAX_RETRIES} retries: {url}: {e}")
+            log.warning(
+                f"{type(e).__name__} on {url}. Retrying in {backoff}s "
+                f"(attempt {attempt}/{__MAX_RETRIES})"
+            )
+            time.sleep(backoff)
+            backoff = min(backoff * 2, __MAX_BACKOFF_SEC)
+
+    raise RuntimeError(f"Unexpected failure after {__MAX_RETRIES} retries: {url}")
+
+
+# ---------------------------------------------------------------------------
+# Pagination helpers
+# ---------------------------------------------------------------------------
+
+
+def paginate_page_number(url, api_key, extra_params=None):
+    """Yield records from a page-number paginated beehiiv endpoint.
+
+    Loops page=1,2,... with limit=100 until page >= total_pages.
+
+    Args:
+        url: The full API endpoint URL (without pagination params).
+        api_key: The beehiiv API bearer token.
+        extra_params: Optional dict of additional query parameters (expand, status, etc.).
+
+    Yields:
+        Individual record dictionaries from the 'data' array in each response.
+    """
+    page = 1
+    total_pages = 1  # Will be updated from first response
+
+    while page <= total_pages:
+        params = {"limit": __PAGE_LIMIT, "page": page}
+        if extra_params:
+            params.update(extra_params)
+
+        response_json = make_api_request(url, api_key, params)
+        data = response_json.get("data", [])
+        total_pages = response_json.get("total_pages", 1)
+
+        for record in data:
+            yield record
+
+        page += 1
+
+
+def paginate_cursor(url, api_key, extra_params=None):
+    """Yield records from a cursor-based paginated beehiiv endpoint.
+
+    Passes cursor from next_cursor in each response. Loops until has_more == false.
+
+    Args:
+        url: The full API endpoint URL (without pagination params).
+        api_key: The beehiiv API bearer token.
+        extra_params: Optional dict of additional query parameters (expand, etc.).
+
+    Yields:
+        Individual record dictionaries from the 'data' array in each response.
+    """
+    cursor = None
+
+    while True:
+        params = {"limit": __PAGE_LIMIT}
+        if cursor:
+            params["cursor"] = cursor
+        if extra_params:
+            params.update(extra_params)
+
+        response_json = make_api_request(url, api_key, params)
+        data = response_json.get("data", [])
+
+        for record in data:
+            yield record
+
+        if not response_json.get("has_more", False):
+            break
+
+        cursor = response_json.get("next_cursor")
+        if not cursor:
+            break
+
+
+# ---------------------------------------------------------------------------
+# Table sync functions
+# ---------------------------------------------------------------------------
+
+
+def sync_publications(api_key, publication_id, state):
+    """Sync the publications table (single record for the configured publication).
+
+    Args:
+        api_key: The beehiiv API bearer token.
+        publication_id: The publication to fetch.
+        state: Current connector state.
+
+    Returns:
+        Updated state dictionary.
+    """
+    log.info("Syncing publications")
+    url = f"{__API_BASE_URL}/publications/{publication_id}"
+    params = {"expand[]": "stats"}
+    response_json = make_api_request(url, api_key, params)
+
+    # The show endpoint returns the publication directly (not wrapped in 'data' array)
+    publication = response_json.get("data", response_json)
+    op.upsert(table="publications", data=publication)
+
+    op.checkpoint(state)
+    log.info("Publications sync complete")
+    return state
+
+
+def sync_subscriptions(api_key, publication_id, state):
+    """Sync subscriptions using cursor-based pagination with incremental sync.
+
+    Uses the created timestamp to fetch only new subscriptions since the last sync.
+
+    Args:
+        api_key: The beehiiv API bearer token.
+        publication_id: The publication to fetch subscriptions for.
+        state: Current connector state.
+
+    Returns:
+        Updated state dictionary.
+    """
+    log.info("Syncing subscriptions")
+    state_key = "subscriptions_last_created"
+    last_created = state.get(state_key)
+
+    url = f"{__API_BASE_URL}/publications/{publication_id}/subscriptions"
+    expand_params = {
+        "expand[]": [
+            "stats",
+            "custom_fields",
+            "subscription_premium_tiers",
+            "newsletter_lists",
+        ]
+    }
+
+    records_processed = 0
+    new_last_created = last_created
+
+    for record in paginate_cursor(url, api_key, expand_params):
+        record_created = record.get("created")
+
+        # Skip records we have already synced (client-side incremental filter)
+        if last_created and record_created and record_created <= last_created:
+            continue
+
+        op.upsert(table="subscriptions", data=record)
+        records_processed += 1
+
+        if record_created and (new_last_created is None or record_created > new_last_created):
+            new_last_created = record_created
+
+        # Checkpoint periodically for high-volume table
+        if records_processed % __CHECKPOINT_INTERVAL == 0:
+            state[state_key] = new_last_created
+            op.checkpoint(state)
+            log.info(f"Subscriptions: checkpointed after {records_processed} records")
+
+    if new_last_created is not None:
+        state[state_key] = new_last_created
+
+    op.checkpoint(state)
+    log.info(f"Subscriptions sync complete: {records_processed} records")
+    return state
+
+
+def sync_posts(api_key, publication_id, state):
+    """Sync posts using page-number pagination with incremental sync.
+
+    Orders by created ascending and tracks the last created timestamp. Strips any
+    accidentally included content fields to avoid syncing large HTML blobs.
+
+    Args:
+        api_key: The beehiiv API bearer token.
+        publication_id: The publication to fetch posts for.
+        state: Current connector state.
+
+    Returns:
+        Updated state dictionary.
+    """
+    log.info("Syncing posts")
+    state_key = "posts_last_created"
+    last_created = state.get(state_key)
+
+    url = f"{__API_BASE_URL}/publications/{publication_id}/posts"
+    extra_params = {
+        "expand[]": "stats",
+        "order_by": "created",
+        "direction": "asc",
+    }
+
+    records_processed = 0
+    new_last_created = last_created
+
+    for record in paginate_page_number(url, api_key, extra_params):
+        record_created = record.get("created")
+
+        # Skip records we have already synced (incremental filter)
+        if last_created and record_created and record_created <= last_created:
+            continue
+
+        # Remove content fields that may have leaked via expand params
+        for content_key in (
+            "free_email_content",
+            "premium_email_content",
+            "free_web_content",
+            "premium_web_content",
+            "free_rss_content",
+            "content",
+        ):
+            record.pop(content_key, None)
+
+        op.upsert(table="posts", data=record)
+        records_processed += 1
+
+        if record_created and (new_last_created is None or record_created > new_last_created):
+            new_last_created = record_created
+
+    if new_last_created is not None:
+        state[state_key] = new_last_created
+
+    op.checkpoint(state)
+    log.info(f"Posts sync complete: {records_processed} records")
+    return state
+
+
+def sync_email_blasts(api_key, publication_id, state):
+    """Sync email blasts using page-number pagination with incremental sync.
+
+    Fetches all statuses (active and inactive) and tracks the created timestamp.
+
+    Args:
+        api_key: The beehiiv API bearer token.
+        publication_id: The publication to fetch email blasts for.
+        state: Current connector state.
+
+    Returns:
+        Updated state dictionary.
+    """
+    log.info("Syncing email_blasts")
+    state_key = "email_blasts_last_created"
+    last_created = state.get(state_key)
+
+    url = f"{__API_BASE_URL}/publications/{publication_id}/email_blasts"
+    extra_params = {
+        "expand[]": "stats",
+        "status": "all",
+    }
+
+    records_processed = 0
+    new_last_created = last_created
+
+    for record in paginate_page_number(url, api_key, extra_params):
+        record_created = record.get("created")
+
+        if last_created and record_created and record_created <= last_created:
+            continue
+
+        op.upsert(table="email_blasts", data=record)
+        records_processed += 1
+
+        if record_created and (new_last_created is None or record_created > new_last_created):
+            new_last_created = record_created
+
+    if new_last_created is not None:
+        state[state_key] = new_last_created
+
+    op.checkpoint(state)
+    log.info(f"Email blasts sync complete: {records_processed} records")
+    return state
+
+
+def sync_automations_and_journeys(api_key, publication_id, state):
+    """Sync automations and their nested automation journeys.
+
+    Automations are fetched with page-number pagination. For each automation, its
+    journeys are fetched from the nested endpoint and upserted into a separate table.
+
+    Args:
+        api_key: The beehiiv API bearer token.
+        publication_id: The publication to fetch automations for.
+        state: Current connector state.
+
+    Returns:
+        Updated state dictionary.
+    """
+    log.info("Syncing automations and automation_journeys")
+
+    automations_url = f"{__API_BASE_URL}/publications/{publication_id}/automations"
+    extra_params = {"expand[]": "stats"}
+    automation_count = 0
+    journey_count = 0
+
+    for automation in paginate_page_number(automations_url, api_key, extra_params):
+        op.upsert(table="automations", data=automation)
+        automation_count += 1
+
+        # Fetch journeys for this automation
+        automation_id = automation.get("id")
+        if automation_id:
+            journeys_url = (
+                f"{__API_BASE_URL}/publications/{publication_id}"
+                f"/automations/{automation_id}/journeys"
+            )
+            for journey in paginate_page_number(journeys_url, api_key):
+                op.upsert(table="automation_journeys", data=journey)
+                journey_count += 1
+
+    op.checkpoint(state)
+    log.info(
+        f"Automations sync complete: {automation_count} automations, " f"{journey_count} journeys"
+    )
+    return state
+
+
+def sync_simple_page_table(api_key, publication_id, state, table_name, endpoint_path, expand=None):
+    """Sync a low-volume table using page-number pagination (full sync each run).
+
+    Args:
+        api_key: The beehiiv API bearer token.
+        publication_id: The publication to fetch data for.
+        state: Current connector state.
+        table_name: The destination table name.
+        endpoint_path: The API path suffix (e.g., '/authors').
+        expand: Optional list of expand parameter values.
+
+    Returns:
+        Updated state dictionary.
+    """
+    log.info(f"Syncing {table_name}")
+    url = f"{__API_BASE_URL}/publications/{publication_id}{endpoint_path}"
+    extra_params = {}
+    if expand:
+        extra_params["expand[]"] = expand
+
+    count = 0
+    for record in paginate_page_number(url, api_key, extra_params or None):
+        op.upsert(table=table_name, data=record)
+        count += 1
+
+    op.checkpoint(state)
+    log.info(f"{table_name} sync complete: {count} records")
+    return state
+
+
+def sync_simple_cursor_table(
+    api_key, publication_id, state, table_name, endpoint_path, expand=None
+):
+    """Sync a table using cursor-based pagination (full sync each run).
+
+    Args:
+        api_key: The beehiiv API bearer token.
+        publication_id: The publication to fetch data for.
+        state: Current connector state.
+        table_name: The destination table name.
+        endpoint_path: The API path suffix (e.g., '/polls').
+        expand: Optional list of expand parameter values.
+
+    Returns:
+        Updated state dictionary.
+    """
+    log.info(f"Syncing {table_name}")
+    url = f"{__API_BASE_URL}/publications/{publication_id}{endpoint_path}"
+    extra_params = {}
+    if expand:
+        extra_params["expand[]"] = expand
+
+    count = 0
+    for record in paginate_cursor(url, api_key, extra_params or None):
+        op.upsert(table=table_name, data=record)
+        count += 1
+
+    op.checkpoint(state)
+    log.info(f"{table_name} sync complete: {count} records")
+    return state
+
+
+def sync_referral_program(api_key, publication_id, state):
+    """Sync referral program milestones using page-number pagination.
+
+    The referral_program endpoint returns a paginated list of milestone records.
+
+    Args:
+        api_key: The beehiiv API bearer token.
+        publication_id: The publication to fetch the referral program for.
+        state: Current connector state.
+
+    Returns:
+        Updated state dictionary.
+    """
+    log.info("Syncing referral_program")
+    url = f"{__API_BASE_URL}/publications/{publication_id}/referral_program"
+
+    try:
+        count = 0
+        for record in paginate_page_number(url, api_key):
+            op.upsert(table="referral_program", data=record)
+            count += 1
+        log.info(f"Referral program sync complete: {count} records")
+    except (RuntimeError, requests.exceptions.HTTPError) as e:
+        log.warning(f"Could not fetch referral_program: {e}")
+
+    op.checkpoint(state)
+    return state
+
+
+def sync_engagements(api_key, publication_id, state):
+    """Sync daily engagement metrics using date-range based fetching.
+
+    Fetches from the last synced date (or 90 days ago on first sync) to today,
+    making requests in chunks of up to 31 days (API maximum).
+
+    Args:
+        api_key: The beehiiv API bearer token.
+        publication_id: The publication to fetch engagements for.
+        state: Current connector state.
+
+    Returns:
+        Updated state dictionary.
+    """
+    log.info("Syncing engagements")
+    state_key = "engagements_last_date"
+    last_date_str = state.get(state_key)
+
+    today = datetime.now(timezone.utc).date()
+
+    if last_date_str:
+        start_date = datetime.strptime(last_date_str, "%Y-%m-%d").date()
+    else:
+        start_date = today - timedelta(days=__ENGAGEMENTS_LOOKBACK_DAYS)
+
+    url = f"{__API_BASE_URL}/publications/{publication_id}/engagements"
+    records_processed = 0
+
+    last_successful_date = start_date
+
+    while start_date <= today:
+        days_to_fetch = min(__ENGAGEMENTS_MAX_DAYS_PER_REQUEST, (today - start_date).days + 1)
+        params = {
+            "start_date": start_date.strftime("%Y-%m-%d"),
+            "number_of_days": days_to_fetch,
+        }
+
+        try:
+            response_json = make_api_request(url, api_key, params)
+            data = response_json.get("data", [])
+            for record in data:
+                op.upsert(table="engagements", data=record)
+                records_processed += 1
+            last_successful_date = start_date + timedelta(days=days_to_fetch)
+        except (RuntimeError, requests.exceptions.HTTPError) as e:
+            log.warning(f"Engagements fetch failed for {start_date}: {e}")
+            break
+
+        start_date += timedelta(days=days_to_fetch)
+
+    state[state_key] = last_successful_date.strftime("%Y-%m-%d")
+    op.checkpoint(state)
+    log.info(f"Engagements sync complete: {records_processed} records")
+    return state
+
+
+def sync_advertisement_opportunities(api_key, publication_id, state):
+    """Sync advertisement opportunities (single response, no pagination).
+
+    Args:
+        api_key: The beehiiv API bearer token.
+        publication_id: The publication to fetch ad opportunities for.
+        state: Current connector state.
+
+    Returns:
+        Updated state dictionary.
+    """
+    log.info("Syncing advertisement_opportunities")
+    url = f"{__API_BASE_URL}/publications/{publication_id}" f"/advertisement_opportunities"
+
+    try:
+        response_json = make_api_request(url, api_key)
+        data = response_json.get("data", [])
+        count = 0
+        for record in data:
+            op.upsert(table="advertisement_opportunities", data=record)
+            count += 1
+        log.info(f"Advertisement opportunities sync complete: {count} records")
+    except (RuntimeError, requests.exceptions.HTTPError) as e:
+        log.warning(f"Could not fetch advertisement_opportunities: {e}")
+
+    op.checkpoint(state)
+    return state
+
+
+# Create the connector object used by Fivetran to run the connector
+connector = Connector(update=update, schema=schema)
+
+if __name__ == "__main__":
+    # Open the configuration.json file and load its contents
+    import json
+
+    with open("configuration.json", "r") as f:
+        configuration = json.load(f)
+    # Run the connector in test mode with the loaded configuration
+    connector.debug(configuration=configuration)

--- a/beehiiv/connector.py
+++ b/beehiiv/connector.py
@@ -5,6 +5,9 @@ See the Technical Reference documentation (https://fivetran.com/docs/connectors/
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
 """
 
+# For reading configuration from a JSON file
+import json
+
 # For adding delay between retries
 import time
 
@@ -38,33 +41,38 @@ __SERVER_ERROR_MIN_STATUS = 500  # Minimum HTTP status code for server errors
 
 
 def validate_configuration(configuration: dict):
-    """Validate the configuration dictionary to ensure it contains all required parameters.
-
+    """
+    Validate the configuration dictionary to ensure it contains all required parameters.
+    This function is called at the start of the update method to ensure that the connector
+    has all necessary configuration values.
     Args:
-        configuration: A dictionary that holds the configuration settings for the connector.
-
+        configuration: a dictionary that holds the configuration settings for the connector.
     Raises:
-        ValueError: If any required configuration parameter is missing.
+        ValueError: if any required configuration parameter is missing or invalid.
     """
     required_configs = ["api_key", "publication_id"]
     for key in required_configs:
-        if key not in configuration:
+        value = configuration.get(key)
+        if value is None:
             raise ValueError(f"Missing required configuration value: {key}")
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"Configuration value must be a non-empty string: {key}")
+
+    # beehiiv publication IDs are prefixed identifiers (e.g. pub_00000000-0000-0000-0000-000000000000)
+    if not configuration["publication_id"].startswith("pub_"):
+        raise ValueError("Configuration value 'publication_id' must start with 'pub_'")
 
 
 def schema(configuration: dict):
-    """Define the schema for all destination tables.
-
-    All tables use 'id' as the primary key (STRING) except engagements which uses 'date'.
-    Nested objects are stored as VARIANT columns
-    (the SDK infers JSON columns automatically when dicts/lists are upserted).
-
-    See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
-
-    Args:
-        configuration: A dictionary that holds the configuration settings for the connector.
     """
+    Define the schema function which lets you configure the schema your connector delivers.
+    See the technical reference documentation for more details on the schema function:
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
+    Args:
+        configuration: a dictionary that holds the configuration settings for the connector.
+    """
+    # All tables use 'id' as the primary key except engagements which uses 'date'.
+    # Nested objects are stored as JSON columns inferred automatically by the SDK.
     return [
         {"table": "publications", "primary_key": ["id"]},
         {"table": "subscriptions", "primary_key": ["id"]},
@@ -87,21 +95,18 @@ def schema(configuration: dict):
 
 
 def update(configuration: dict, state: dict):
-    """Sync data from the beehiiv API into all destination tables.
-
-    This function is called by Fivetran during each sync. It handles both incremental
-    and full-sync tables, checkpointing state after each table completes.
-
-    See the technical reference documentation for more details on the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
-
-    Args:
-        configuration: A dictionary containing connection details (api_key, publication_id).
-        state: A dictionary containing state information from previous runs.
-               The state dictionary is empty for the first sync or for any full re-sync.
     """
-    log.info("beehiiv connector: starting sync")
+    Define the update function, which is a required function, and is called by Fivetran during each sync.
+    See the technical reference documentation for more details on the update function
+    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    Args:
+        configuration: A dictionary containing connection details
+        state: A dictionary containing state information from previous runs
+        The state dictionary is empty for the first sync or for any full re-sync
+    """
+    log.warning("Examples: Connectors - Beehiiv API")
 
+    # Validate the configuration to ensure it contains all required values.
     validate_configuration(configuration)
 
     api_key = configuration["api_key"]
@@ -308,8 +313,16 @@ def sync_publications(api_key, publication_id, state):
 
     # The show endpoint returns the publication directly (not wrapped in 'data' array)
     publication = response_json.get("data", response_json)
+
+    # The 'upsert' operation is used to insert or update data in the destination table.
+    # The first argument is the name of the destination table.
+    # The second argument is a dictionary containing the record to be upserted.
     op.upsert(table="publications", data=publication)
 
+    # Save the progress by checkpointing the state. This is important for ensuring that the
+    # sync process can resume from the correct position in case of next sync or interruptions.
+    # Learn more about how and where to checkpoint by reading our best practices documentation:
+    # https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets
     op.checkpoint(state)
     log.info("Publications sync complete")
     return state
@@ -318,7 +331,9 @@ def sync_publications(api_key, publication_id, state):
 def sync_subscriptions(api_key, publication_id, state):
     """Sync subscriptions using cursor-based pagination with incremental sync.
 
-    Uses the created timestamp to fetch only new subscriptions since the last sync.
+    Requests records ordered by created descending (newest first) so pagination can stop
+    as soon as a record at or before the last synced created timestamp is reached,
+    avoiding a full re-read of subscription history on every sync.
 
     Args:
         api_key: The beehiiv API bearer token.
@@ -333,40 +348,54 @@ def sync_subscriptions(api_key, publication_id, state):
     last_created = state.get(state_key)
 
     url = f"{__API_BASE_URL}/publications/{publication_id}/subscriptions"
-    expand_params = {
+    extra_params = {
         "expand[]": [
             "stats",
             "custom_fields",
             "subscription_premium_tiers",
             "newsletter_lists",
-        ]
+        ],
+        # Order newest-first so incremental syncs can stop paginating early instead of
+        # reading the full subscription history on every run.
+        "order_by": "created",
+        "direction": "desc",
     }
 
     records_processed = 0
     new_last_created = last_created
 
-    for record in paginate_cursor(url, api_key, expand_params):
+    for record in paginate_cursor(url, api_key, extra_params):
         record_created = record.get("created")
 
-        # Skip records we have already synced (client-side incremental filter)
+        # Records arrive newest-first, so once we reach a record at or before the last
+        # synced timestamp all remaining records have already been synced. Stop paginating.
         if last_created and record_created and record_created <= last_created:
-            continue
+            break
 
+        # The 'upsert' operation is used to insert or update data in the destination table.
+        # The first argument is the name of the destination table.
+        # The second argument is a dictionary containing the record to be upserted.
         op.upsert(table="subscriptions", data=record)
         records_processed += 1
 
         if record_created and (new_last_created is None or record_created > new_last_created):
             new_last_created = record_created
 
-        # Checkpoint periodically for high-volume table
+        # Checkpoint periodically for this high-volume table so already-delivered records
+        # can be safely written to the destination during long syncs. The incremental cursor
+        # is intentionally not advanced here: records arrive newest-first, so advancing it
+        # mid-sync could skip older unsynced records if the sync is interrupted.
+        # Learn more about how and where to checkpoint by reading our best practices documentation:
+        # https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets
         if records_processed % __CHECKPOINT_INTERVAL == 0:
-            state[state_key] = new_last_created
             op.checkpoint(state)
             log.info(f"Subscriptions: checkpointed after {records_processed} records")
 
     if new_last_created is not None:
         state[state_key] = new_last_created
 
+    # Save the progress by checkpointing the state. This is important for ensuring that the
+    # sync process can resume from the correct position in case of next sync or interruptions.
     op.checkpoint(state)
     log.info(f"Subscriptions sync complete: {records_processed} records")
     return state
@@ -375,8 +404,9 @@ def sync_subscriptions(api_key, publication_id, state):
 def sync_posts(api_key, publication_id, state):
     """Sync posts using page-number pagination with incremental sync.
 
-    Orders by created ascending and tracks the last created timestamp. Strips any
-    accidentally included content fields to avoid syncing large HTML blobs.
+    Orders by created descending (newest first) so pagination can stop as soon as a
+    previously synced record is reached. Strips any accidentally included content
+    fields to avoid syncing large HTML blobs.
 
     Args:
         api_key: The beehiiv API bearer token.
@@ -393,8 +423,10 @@ def sync_posts(api_key, publication_id, state):
     url = f"{__API_BASE_URL}/publications/{publication_id}/posts"
     extra_params = {
         "expand[]": "stats",
+        # Order newest-first so incremental syncs can stop paginating early instead of
+        # reading the full post history on every run.
         "order_by": "created",
-        "direction": "asc",
+        "direction": "desc",
     }
 
     records_processed = 0
@@ -403,9 +435,10 @@ def sync_posts(api_key, publication_id, state):
     for record in paginate_page_number(url, api_key, extra_params):
         record_created = record.get("created")
 
-        # Skip records we have already synced (incremental filter)
+        # Records arrive newest-first, so once we reach a record at or before the last
+        # synced timestamp all remaining records have already been synced. Stop paginating.
         if last_created and record_created and record_created <= last_created:
-            continue
+            break
 
         # Remove content fields that may have leaked via expand params
         for content_key in (
@@ -418,15 +451,27 @@ def sync_posts(api_key, publication_id, state):
         ):
             record.pop(content_key, None)
 
+        # The 'upsert' operation is used to insert or update data in the destination table.
+        # The first argument is the name of the destination table.
+        # The second argument is a dictionary containing the record to be upserted.
         op.upsert(table="posts", data=record)
         records_processed += 1
 
         if record_created and (new_last_created is None or record_created > new_last_created):
             new_last_created = record_created
 
+        # Checkpoint periodically so already-delivered records can be safely written to the
+        # destination during long syncs. The incremental cursor is intentionally not advanced
+        # here because records arrive newest-first (see sync_subscriptions).
+        if records_processed % __CHECKPOINT_INTERVAL == 0:
+            op.checkpoint(state)
+            log.info(f"Posts: checkpointed after {records_processed} records")
+
     if new_last_created is not None:
         state[state_key] = new_last_created
 
+    # Save the progress by checkpointing the state. This is important for ensuring that the
+    # sync process can resume from the correct position in case of next sync or interruptions.
     op.checkpoint(state)
     log.info(f"Posts sync complete: {records_processed} records")
     return state
@@ -461,18 +506,32 @@ def sync_email_blasts(api_key, publication_id, state):
     for record in paginate_page_number(url, api_key, extra_params):
         record_created = record.get("created")
 
+        # Skip records we have already synced. The email_blasts endpoint does not document
+        # server-side ordering, so filtering happens client-side; volumes are low here.
         if last_created and record_created and record_created <= last_created:
             continue
 
+        # The 'upsert' operation is used to insert or update data in the destination table.
+        # The first argument is the name of the destination table.
+        # The second argument is a dictionary containing the record to be upserted.
         op.upsert(table="email_blasts", data=record)
         records_processed += 1
 
         if record_created and (new_last_created is None or record_created > new_last_created):
             new_last_created = record_created
 
+        # Checkpoint periodically so already-delivered records can be safely written to the
+        # destination during long syncs. The incremental cursor is intentionally not advanced
+        # here because the source ordering is not guaranteed.
+        if records_processed % __CHECKPOINT_INTERVAL == 0:
+            op.checkpoint(state)
+            log.info(f"Email blasts: checkpointed after {records_processed} records")
+
     if new_last_created is not None:
         state[state_key] = new_last_created
 
+    # Save the progress by checkpointing the state. This is important for ensuring that the
+    # sync process can resume from the correct position in case of next sync or interruptions.
     op.checkpoint(state)
     log.info(f"Email blasts sync complete: {records_processed} records")
     return state
@@ -500,6 +559,7 @@ def sync_automations_and_journeys(api_key, publication_id, state):
     journey_count = 0
 
     for automation in paginate_page_number(automations_url, api_key, extra_params):
+        # The 'upsert' operation is used to insert or update data in the destination table.
         op.upsert(table="automations", data=automation)
         automation_count += 1
 
@@ -514,6 +574,8 @@ def sync_automations_and_journeys(api_key, publication_id, state):
                 op.upsert(table="automation_journeys", data=journey)
                 journey_count += 1
 
+    # Save the progress by checkpointing the state. This is important for ensuring that the
+    # sync process can resume from the correct position in case of next sync or interruptions.
     op.checkpoint(state)
     log.info(
         f"Automations sync complete: {automation_count} automations, " f"{journey_count} journeys"
@@ -543,9 +605,12 @@ def sync_simple_page_table(api_key, publication_id, state, table_name, endpoint_
 
     count = 0
     for record in paginate_page_number(url, api_key, extra_params or None):
+        # The 'upsert' operation is used to insert or update data in the destination table.
         op.upsert(table=table_name, data=record)
         count += 1
 
+    # Save the progress by checkpointing the state. This is important for ensuring that the
+    # sync process can resume from the correct position in case of next sync or interruptions.
     op.checkpoint(state)
     log.info(f"{table_name} sync complete: {count} records")
     return state
@@ -575,9 +640,12 @@ def sync_simple_cursor_table(
 
     count = 0
     for record in paginate_cursor(url, api_key, extra_params or None):
+        # The 'upsert' operation is used to insert or update data in the destination table.
         op.upsert(table=table_name, data=record)
         count += 1
 
+    # Save the progress by checkpointing the state. This is important for ensuring that the
+    # sync process can resume from the correct position in case of next sync or interruptions.
     op.checkpoint(state)
     log.info(f"{table_name} sync complete: {count} records")
     return state
@@ -602,12 +670,15 @@ def sync_referral_program(api_key, publication_id, state):
     try:
         count = 0
         for record in paginate_page_number(url, api_key):
+            # The 'upsert' operation is used to insert or update data in the destination table.
             op.upsert(table="referral_program", data=record)
             count += 1
         log.info(f"Referral program sync complete: {count} records")
     except (RuntimeError, requests.exceptions.HTTPError) as e:
         log.warning(f"Could not fetch referral_program: {e}")
 
+    # Save the progress by checkpointing the state. This is important for ensuring that the
+    # sync process can resume from the correct position in case of next sync or interruptions.
     op.checkpoint(state)
     return state
 
@@ -653,6 +724,7 @@ def sync_engagements(api_key, publication_id, state):
             response_json = make_api_request(url, api_key, params)
             data = response_json.get("data", [])
             for record in data:
+                # The 'upsert' operation is used to insert or update data in the destination table.
                 op.upsert(table="engagements", data=record)
                 records_processed += 1
             last_successful_date = start_date + timedelta(days=days_to_fetch)
@@ -663,6 +735,9 @@ def sync_engagements(api_key, publication_id, state):
         start_date += timedelta(days=days_to_fetch)
 
     state[state_key] = last_successful_date.strftime("%Y-%m-%d")
+
+    # Save the progress by checkpointing the state. This is important for ensuring that the
+    # sync process can resume from the correct position in case of next sync or interruptions.
     op.checkpoint(state)
     log.info(f"Engagements sync complete: {records_processed} records")
     return state
@@ -687,24 +762,32 @@ def sync_advertisement_opportunities(api_key, publication_id, state):
         data = response_json.get("data", [])
         count = 0
         for record in data:
+            # The 'upsert' operation is used to insert or update data in the destination table.
             op.upsert(table="advertisement_opportunities", data=record)
             count += 1
         log.info(f"Advertisement opportunities sync complete: {count} records")
     except (RuntimeError, requests.exceptions.HTTPError) as e:
         log.warning(f"Could not fetch advertisement_opportunities: {e}")
 
+    # Save the progress by checkpointing the state. This is important for ensuring that the
+    # sync process can resume from the correct position in case of next sync or interruptions.
     op.checkpoint(state)
     return state
 
 
-# Create the connector object used by Fivetran to run the connector
+# Create the connector object using the schema and update functions
 connector = Connector(update=update, schema=schema)
 
+# Check if the script is being run as the main module.
+# This is Python's standard entry method allowing your script to be run directly from the
+# command line or IDE 'run' button.
+# This is useful for debugging while you write your code. Note this method is not called by
+# Fivetran when executing your connector in production.
+# Please test using the Fivetran debug command prior to finalizing and deploying your connector.
 if __name__ == "__main__":
     # Open the configuration.json file and load its contents
-    import json
-
     with open("configuration.json", "r") as f:
         configuration = json.load(f)
-    # Run the connector in test mode with the loaded configuration
+
+    # Test the connector locally
     connector.debug(configuration=configuration)


### PR DESCRIPTION
### Description of Change
Adds a new community connector for [beehiiv](https://www.beehiiv.com/), a newsletter platform. The connector syncs 17 tables from the [beehiiv API v2](https://developers.beehiiv.com/) for a single publication: publications, subscriptions, posts, email_blasts, automations, automation_journeys, authors, segments, custom_fields, newsletter_lists, tiers, referral_program, polls, condition_sets, post_templates, engagements, and advertisement_opportunities.

Key implementation details:
- Incremental sync with `created`-timestamp cursors for high-volume tables (subscriptions, posts, email_blasts) and a date-range cursor for engagements; full sync for low-volume reference tables
- Handles both page-number and cursor-based pagination patterns used across the beehiiv API
- Retry with exponential backoff for rate limits (429) and transient server errors
- Graceful handling of endpoints not enabled for a publication (e.g. referral program) — logged as warnings without failing the sync
- Frequent checkpointing so interrupted syncs resume without data loss

Configuration: `api_key` (Bearer token) and `publication_id`.

Also updates the root `README.md` to list the connector in the SaaS & APIs section.

This connector was contributed by [AngelList](https://www.angellist.com/), where it has been running in production via the Connector SDK since May 2026.

### Testing
Ran `fivetran debug --configuration configuration.json` against a live beehiiv publication: **SYNC SUCCEEDED** with 23,034 upserts across 17 tables (schema changes: 17, checkpoints: 38) in 3:21. Verified table contents in `files/warehouse.db` with DuckDB. Also verified `flake8` (repo `.flake8` config) and `black --line-length 99` pass cleanly.

<img width="1100" height="710" alt="image" src="https://github.com/user-attachments/assets/3b818889-63b5-486b-b4d5-fcbdde7ae030" />


### Checklist
Some tips and links to help validate your PR:

- [x] Tested the connector with `fivetran debug` command.
- [x] Added/Updated example-specific README.md file, see [the README template](https://github.com/fivetran/community_connectors/tree/main/_template_connector/README_template.md) for the required structure and guidelines.
- [x] Followed Python Coding Standards, [refer here](https://github.com/fivetran/community_connectors/blob/main/PYTHON_CODING_STANDARDS.md)
