### PR TITLE
feature(connectors): add federal register connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ For SDK installation and setup, visit the main [Fivetran Connector SDK repositor
 - **[discord](https://github.com/fivetran/community_connectors/tree/main/discord)** - Sync data from Discord
 - **[docusign](https://github.com/fivetran/community_connectors/tree/main/docusign)** - Sync data from Docusign eSignature API
 - **[elastic_email](https://github.com/fivetran/community_connectors/tree/main/elastic_email)** - Sync email marketing data from Elastic Email
+- **[federal_register](https://github.com/fivetran/community_connectors/tree/main/federal_register)** - Sync rules, proposed rules, notices, and presidential documents from the Federal Register API
 - **[fleetio](https://github.com/fivetran/community_connectors/tree/main/fleetio)** - Sync fleet management data from Fleetio
 - **[fred](https://github.com/fivetran/community_connectors/tree/main/fred)** - Sync economic data from Federal Reserve Economic Data (FRED)
 - **[github](https://github.com/fivetran/community_connectors/tree/main/github)** - Sync repository data, commits, and pull requests from GitHub

--- a/federal_register/README.md
+++ b/federal_register/README.md
@@ -1,0 +1,116 @@
+# Federal Register Connector Example
+
+## Connector overview
+
+This connector syncs documents from the [Federal Register API](https://www.federalregister.gov/developers/documentation/api/v1) into a Fivetran destination. The Federal Register is the official daily journal of the United States government, publishing rules, proposed rules, notices, and presidential documents from federal agencies. Each document carries a stable document number, a publication date, a document type, the issuing agencies, and links to the HTML and PDF renderings.
+
+The API is public and requires no credentials. The connector syncs incrementally on `publication_date`, oldest first, and requires no authentication. Typical uses are regulatory change monitoring, agency rulemaking analysis, compliance tracking, and building a searchable corpus of federal notices.
+
+## Requirements
+
+- [Supported Python versions](https://github.com/fivetran/community_connectors/blob/main/README.md#requirements)
+- Operating system:
+  - Windows: 10 or later (64-bit only)
+  - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
+  - Linux: Distributions such as Ubuntu 20.04 or later, Debian 10 or later, or Amazon Linux 2 or later (arm64 or x86_64)
+
+## Getting started
+
+Refer to the [Connector SDK Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
+
+To initialize a new Connector SDK project using this connector as a starting point, run:
+
+```
+fivetran init --template federal_register
+```
+
+`fivetran init` initializes a new Connector SDK project by setting up the project structure, configuration files, and a connector you can run immediately with `fivetran debug`. For more information on `fivetran init`, refer to the [Connector SDK `init` documentation](https://fivetran.com/docs/connector-sdk/connector-development-and-configuration/connector-sdk-commands#fivetraninit).
+
+## Features
+
+- Incremental sync keyed on a compound `(publication_date, document_number)` cursor, so each run transfers only documents published after the previous checkpoint.
+- Cursor-based pagination that follows the API's own `next_page_url`, which carries a stable `search_after` cursor for deep pagination.
+- Configurable record limit per sync. Because the cursor is compound, the limit is a true ceiling: a run stops on an exact document and the next run resumes on the following one.
+- Retry with exponential backoff on transient transport and server errors, and immediate failure on client errors that a retry cannot fix.
+- No credentials required. The Federal Register API is public.
+
+## Configuration file
+
+The connector requires no authentication, so every configuration value is optional and has a documented default. Supply only the values you want to override.
+
+```
+{
+  "initial_sync_start_date": "<YOUR_INITIAL_SYNC_START_DATE>",
+  "page_size": "<YOUR_PAGE_SIZE>",
+  "max_records_per_sync": "<YOUR_MAX_RECORDS_PER_SYNC>"
+}
+```
+
+### Configuration parameters
+
+- `initial_sync_start_date` – The inclusive lower bound of the first sync, in `YYYY-MM-DD` format. Used only when no previous state exists. Defaults to `2024-01-01`. Refer to `def validate_configuration(configuration: dict)`.
+- `page_size` – Documents requested per API call, between 1 and 1000. Defaults to 100. The API rejects any larger value.
+- `max_records_per_sync` – Upper bound on documents upserted in a single sync, where 0 means no limit. Defaults to 0. Because the cursor is compound, the run stops on the exact record that meets the limit and the next sync resumes on the following one. Refer to `def update(configuration: dict, state: dict)`.
+
+> Note: Do not add a `requirements.txt` file. This connector depends only on `requests`, which the Fivetran runtime provides.
+
+## Authentication
+
+The Federal Register API is public and requires no API key, token, or account. No authentication configuration is needed and the connector sends no credentials.
+
+## Pagination
+
+The connector uses cursor-based pagination. The first request of each sync sets the `publication_date` lower bound and `order=oldest`, and every subsequent request follows the `next_page_url` returned in the previous response. That URL carries a `search_after` cursor encoding the publication date and document number of the last row on the page, which is what makes deep pagination stable. Refer to `def build_initial_url(start_date, page_size)`.
+
+> Note: The walk terminates when `next_page_url` is absent rather than when a page is empty.
+
+## Data handling
+
+Each document is flattened into a single row in the `document` table, keyed on `document_number`. Refer to `def flatten_document(record: dict)`.
+
+The `agencies` field is a list of objects. It is flattened into two delimited strings: `agency_ids` by `def join_agency_ids(agencies)` and `agency_names` by `def join_agency_names(agencies)`. An empty agency list is stored as null rather than an empty string, and the cleaned agency name is preferred over its raw form.
+
+The API field `type` is delivered as the column `document_type`. The name `type` reads ambiguously as a column and is refused by some warehouses as an identifier, so it is renamed at the source.
+
+Incremental state is a compound cursor: the `publication_date` plus the `document_number` within that date. The API's `publication_date` filter is inclusive and day-granular, and a single day can carry dozens of documents, so a date-only cursor would either re-fetch a whole day on every sync or skip records. The document number is the same value the API sorts on within a day, so pairing it with the date lets a bounded run stop between two documents on the same day and resume exactly there. On resume, the inclusive lower bound re-serves the last synced day and the connector skips every document at or before the stored cursor, which is exactly the set already delivered. Delivery is therefore at-least-once, and the primary key makes the repeated upsert idempotent. A sync that returns no records re-checkpoints the existing cursor rather than resetting it.
+
+Documents that arrive without a document number are skipped and logged, because the document number is the primary key.
+
+## Error handling
+
+Refer to `def get_api_response(url: str)`.
+
+- Transient failures – Connection errors, timeouts, and 5xx responses are retried up to three times with exponential backoff starting at two seconds.
+- Client errors – A 4xx response other than 429 indicates a malformed request, such as an out-of-range page size. These fail immediately with the response body included, because a retry cannot change the outcome and only delays the error the operator needs to see.
+- Rate limiting – A 429 response is treated as transient and retried with backoff.
+- Configuration errors – Invalid values raise `ValueError` before any request is sent, so a malformed page size fails at the start of the sync rather than midway through it.
+
+## Tables created
+
+The connector creates one table.
+
+`DOCUMENT`
+
+Primary key: `document_number`
+
+| Column | Type | Description |
+| --- | --- | --- |
+| document_number | STRING | The Federal Register document number. Primary key |
+| publication_date | NAIVE_DATE | Date the document was published. Drives the incremental sync |
+| document_type | STRING | Document type, for example Rule, Proposed Rule, Notice, or Presidential Document. Renamed from the API field `type` |
+| title | STRING | Document title |
+| abstract | STRING | Document abstract, where one is provided |
+| excerpts | STRING | Short text excerpts from the document, where provided |
+| html_url | STRING | URL of the document on federalregister.gov |
+| pdf_url | STRING | URL of the document PDF on govinfo.gov |
+| public_inspection_pdf_url | STRING | URL of the public inspection PDF, where available |
+| agency_ids | STRING | Comma-separated Federal Register agency ids for the document |
+| agency_names | STRING | Semicolon-separated agency names for the document |
+
+## Additional considerations
+
+The examples provided are intended as starting points for your own connector development. While we review them for quality and functionality, we cannot guarantee their suitability for your specific use case. Please test thoroughly before deploying to production.
+
+The Federal Register holds documents back to 1994. A first sync with an early `initial_sync_start_date` and no record limit therefore transfers a substantial volume, so set a recent `initial_sync_start_date`, or set `max_records_per_sync`, when testing.
+
+The API exposes richer document detail through per-document endpoints, including full text, regulatory dockets, and CFR references. This connector syncs the document index fields only.

--- a/federal_register/README.md
+++ b/federal_register/README.md
@@ -38,13 +38,15 @@ fivetran init --template federal_register
 
 The connector requires no authentication, so every configuration value is optional and has a documented default. Supply only the values you want to override.
 
-```
+```json
 {
   "initial_sync_start_date": "<YOUR_INITIAL_SYNC_START_DATE>",
   "page_size": "<YOUR_PAGE_SIZE>",
   "max_records_per_sync": "<YOUR_MAX_RECORDS_PER_SYNC>"
 }
 ```
+
+> Note: When submitting connector code as a community connector in the open-source [Community Connector repository](https://github.com/fivetran/community_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ### Configuration parameters
 
@@ -89,7 +91,7 @@ Refer to `def get_api_response(url: str)`.
 
 The connector creates one table.
 
-`DOCUMENT`
+`document`
 
 Primary key: `document_number`
 

--- a/federal_register/README.md
+++ b/federal_register/README.md
@@ -111,7 +111,7 @@ Primary key: `document_number`
 
 ## Additional considerations
 
-The examples provided are intended as starting points for your own connector development. While we review them for quality and functionality, we cannot guarantee their suitability for your specific use case. Please test thoroughly before deploying to production.
+The examples provided are intended to help you effectively use Fivetran's Connector SDK. While we've tested the code, Fivetran cannot be held responsible for any unexpected or negative consequences that may arise from using these examples. For inquiries, please reach out to our Support team.
 
 The Federal Register holds documents back to 1994. A first sync with an early `initial_sync_start_date` and no record limit therefore transfers a substantial volume, so set a recent `initial_sync_start_date`, or set `max_records_per_sync`, when testing.
 

--- a/federal_register/configuration.json
+++ b/federal_register/configuration.json
@@ -1,0 +1,5 @@
+{
+  "initial_sync_start_date": "<YOUR_INITIAL_SYNC_START_DATE>",
+  "page_size": "<YOUR_PAGE_SIZE>",
+  "max_records_per_sync": "<YOUR_MAX_RECORDS_PER_SYNC>"
+}

--- a/federal_register/connector.py
+++ b/federal_register/connector.py
@@ -1,0 +1,398 @@
+"""This connector syncs Federal Register documents (rules, proposed rules, notices, and presidential documents) from the Federal Register API to a Fivetran destination.
+See the Technical Reference documentation
+(https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+and the Best Practices documentation
+(https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+"""
+
+# For reading configuration from a JSON file
+import json
+
+# For validating the configured start date
+from datetime import datetime
+
+# For handling request delays during retries
+import time
+
+# For building query strings safely
+import urllib.parse
+
+# For making HTTP requests to the Federal Register API
+import requests
+
+# Import required classes from fivetran_connector_sdk
+from fivetran_connector_sdk import Connector
+
+# For enabling Logs in your connector code
+from fivetran_connector_sdk import Logging as log
+
+# For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
+from fivetran_connector_sdk import Operations as op
+
+# Base URL for the Federal Register documents API
+__BASE_URL = "https://www.federalregister.gov/api/v1/documents.json"
+
+# Fields requested from the API. Pinning the field set keeps the delivered schema
+# stable regardless of new fields the API may add later.
+__FIELDS = [
+    "document_number",
+    "publication_date",
+    "type",
+    "title",
+    "abstract",
+    "excerpts",
+    "html_url",
+    "pdf_url",
+    "public_inspection_pdf_url",
+    "agencies",
+]
+
+# Maximum number of retry attempts for API requests
+__MAX_RETRIES = 3
+
+# Base delay in seconds for exponential backoff retries
+__BASE_DELAY_SECONDS = 2
+
+# Timeout in seconds for HTTP requests
+__REQUEST_TIMEOUT_SECONDS = 60
+
+# Maximum page size the Federal Register API accepts.
+__MAX_PAGE_SIZE = 1000
+
+# Default page size when none is configured.
+__DEFAULT_PAGE_SIZE = 100
+
+# Number of records processed between checkpoints
+__CHECKPOINT_INTERVAL = 1000
+
+# Publication date used when no state exists and no start date is configured.
+__DEFAULT_SYNC_START_DATE = "2024-01-01"
+
+# Date format the API uses for the publication_date filter and field.
+__DATE_FORMAT = "%Y-%m-%d"
+
+
+def validate_configuration(configuration: dict):
+    """
+    Validate the configuration dictionary to ensure it contains all required parameters.
+    This function is called at the start of the update method to ensure that the connector has
+    all necessary configuration values.
+    Args:
+        configuration: a dictionary that holds the configuration settings for the connector.
+    Raises:
+        ValueError: if any configuration parameter is missing, malformed, or out of range.
+    """
+    # The Federal Register API requires no authentication, so there are no
+    # required secrets. Every value below is optional with a documented default,
+    # but any value that IS supplied must be usable -- a malformed page size
+    # should fail here, at configuration time, rather than as an HTTP error
+    # midway through a sync.
+    page_size = configuration.get("page_size", str(__DEFAULT_PAGE_SIZE))
+    if not str(page_size).isdigit() or not 1 <= int(page_size) <= __MAX_PAGE_SIZE:
+        raise ValueError(
+            f"Invalid configuration value for page_size: {page_size}. "
+            f"Must be an integer between 1 and {__MAX_PAGE_SIZE}."
+        )
+
+    max_records = configuration.get("max_records_per_sync", "0")
+    if not str(max_records).isdigit():
+        raise ValueError(
+            f"Invalid configuration value for max_records_per_sync: {max_records}. "
+            "Must be a non-negative integer, where 0 means no limit."
+        )
+
+    start_date = configuration.get("initial_sync_start_date", __DEFAULT_SYNC_START_DATE)
+    try:
+        datetime.strptime(start_date, __DATE_FORMAT)
+    except ValueError:
+        raise ValueError(
+            f"Invalid configuration value for initial_sync_start_date: {start_date}. "
+            f"Must match {__DATE_FORMAT}, for example 2024-01-01."
+        )
+
+
+def schema(configuration: dict):
+    """
+    Define the schema function which lets you configure the schema your connector delivers.
+    See the technical reference documentation for more details on the schema function:
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
+    Args:
+        configuration: a dictionary that holds the configuration settings for the connector.
+    """
+    return [
+        {
+            "table": "document",
+            "primary_key": ["document_number"],
+            "columns": {
+                "document_number": "STRING",
+                "publication_date": "NAIVE_DATE",
+                "document_type": "STRING",
+                "title": "STRING",
+                "abstract": "STRING",
+                "excerpts": "STRING",
+                "html_url": "STRING",
+                "pdf_url": "STRING",
+                "public_inspection_pdf_url": "STRING",
+                "agency_ids": "STRING",
+                "agency_names": "STRING",
+            },
+        }
+    ]
+
+
+def get_api_response(url: str):
+    """
+    Send a GET request to the Federal Register API and return the decoded JSON response.
+    Retries on transient transport and server errors with exponential backoff.
+    Args:
+        url: the fully-qualified request URL, including any query string.
+    Returns:
+        The decoded JSON response body as a dictionary.
+    Raises:
+        RuntimeError: if the API cannot be reached successfully within the retry budget.
+    """
+    last_error = None
+    for attempt in range(__MAX_RETRIES):
+        try:
+            response = requests.get(url, timeout=__REQUEST_TIMEOUT_SECONDS)
+
+            # A 4xx other than 429 means the request itself is wrong -- a bad
+            # filter, an out-of-range page size. Retrying cannot fix it and only
+            # delays a failure the operator needs to see, so fail immediately.
+            if 400 <= response.status_code < 500 and response.status_code != 429:
+                raise RuntimeError(
+                    f"Federal Register API rejected the request with HTTP "
+                    f"{response.status_code}: {response.text[:500]}"
+                )
+
+            response.raise_for_status()
+            return response.json()
+        except (requests.exceptions.RequestException, ValueError) as error:
+            last_error = error
+            if attempt < __MAX_RETRIES - 1:
+                delay = __BASE_DELAY_SECONDS * (2**attempt)
+                log.warning(
+                    f"Federal Register API request failed (attempt {attempt + 1} of "
+                    f"{__MAX_RETRIES}), retrying in {delay}s: {error}"
+                )
+                time.sleep(delay)
+
+    raise RuntimeError(
+        f"Federal Register API request failed after {__MAX_RETRIES} attempts: {last_error}"
+    )
+
+
+def build_initial_url(start_date: str, page_size: int):
+    """
+    Build the first request URL for an incremental sync.
+    Documents are returned oldest first so the compound (publication_date,
+    document_number) cursor advances monotonically and a bounded run can resume
+    exactly where it stopped.
+    Args:
+        start_date: inclusive lower bound of the sync window, as YYYY-MM-DD.
+        page_size: number of records to request per page.
+    Returns:
+        The fully-qualified URL for the first page.
+    """
+    # urlencode encodes the configured start_date and page size, so no
+    # config-derived value reaches the URL unescaped.
+    query = [
+        ("conditions[publication_date][gte]", start_date),
+        ("order", "oldest"),
+        ("per_page", str(page_size)),
+    ]
+    query += [("fields[]", field) for field in __FIELDS]
+    return f"{__BASE_URL}?{urllib.parse.urlencode(query)}"
+
+
+def join_agency_ids(agencies: list):
+    """
+    Flatten the agency id list of a document into a delimited string.
+    Args:
+        agencies: the raw agencies array, which may be empty.
+    Returns:
+        A comma-separated string of agency ids, or None when there are none.
+    """
+    ids = [str(agency.get("id")) for agency in agencies if agency.get("id") is not None]
+    return ",".join(ids) if ids else None
+
+
+def join_agency_names(agencies: list):
+    """
+    Flatten the agency name list of a document into a delimited string.
+    The API exposes both a cleaned name and a raw_name; the cleaned name is
+    preferred and raw_name is the fallback.
+    Args:
+        agencies: the raw agencies array, which may be empty.
+    Returns:
+        A semicolon-separated string of agency names, or None when there are none.
+    """
+    names = [agency.get("name") or agency.get("raw_name") for agency in agencies]
+    names = [name for name in names if name]
+    return "; ".join(names) if names else None
+
+
+def flatten_document(record: dict):
+    """
+    Flatten one Federal Register API document into a single destination row.
+    Args:
+        record: one element of the API response "results" array.
+    Returns:
+        A dictionary whose keys match the document table columns.
+    """
+    agencies = record.get("agencies") or []
+
+    return {
+        "document_number": record.get("document_number"),
+        "publication_date": record.get("publication_date"),
+        # 'type' is renamed to 'document_type': 'type' reads ambiguously as a
+        # column and is refused by some warehouses as an identifier.
+        "document_type": record.get("type"),
+        "title": record.get("title"),
+        "abstract": record.get("abstract"),
+        "excerpts": record.get("excerpts"),
+        "html_url": record.get("html_url"),
+        "pdf_url": record.get("pdf_url"),
+        "public_inspection_pdf_url": record.get("public_inspection_pdf_url"),
+        "agency_ids": join_agency_ids(agencies),
+        "agency_names": join_agency_names(agencies),
+    }
+
+
+def update(configuration: dict, state: dict):
+    """
+    Define the update function, which is a required function, and is called by Fivetran during each sync.
+    See the technical reference documentation for more details on the update function
+    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    Args:
+        configuration: A dictionary containing connection details
+        state: A dictionary containing state information from previous runs
+        The state dictionary is empty for the first sync or for any full re-sync
+    """
+    log.warning("Example: Source Examples - Federal Register Documents")
+
+    validate_configuration(configuration=configuration)
+
+    page_size = int(configuration.get("page_size", __DEFAULT_PAGE_SIZE))
+    max_records = int(configuration.get("max_records_per_sync", "0"))
+
+    # The cursor is compound: a publication_date plus the document_number within
+    # that date. The API's publication_date filter is inclusive and day-granular,
+    # and a single day carries many documents, so a date-only cursor would either
+    # re-fetch a whole day every sync or skip records. The document_number
+    # tiebreaker lets a bounded run stop between two documents on the same day and
+    # resume exactly there. document_number is the same value the API sorts on
+    # (its search_after cursor encodes publication_date and document_number), so
+    # this ordering matches the server's.
+    last_date = state.get(
+        "last_publication_date",
+        configuration.get("initial_sync_start_date", __DEFAULT_SYNC_START_DATE),
+    )
+    last_document = state.get("last_document_number", "")
+
+    log.info(
+        f"Syncing Federal Register documents published on or after {last_date} "
+        f"(page size {page_size}, record limit {max_records or 'none'})"
+    )
+
+    url = build_initial_url(last_date, page_size)
+    cursor_date = last_date
+    cursor_document = last_document
+    record_count = 0
+    limit_reached = False
+
+    while url:
+        response = get_api_response(url)
+        records = response.get("results", [])
+
+        for record in records:
+            document_number = record.get("document_number")
+            publication_date = record.get("publication_date")
+
+            # A record with no document_number cannot be keyed in the
+            # destination. Skip it loudly rather than upserting a null key.
+            if not document_number:
+                log.warning("Skipping a record with no document_number")
+                continue
+
+            # The lower bound is inclusive, so a resume re-requests the last
+            # synced day. Skip any document at or before the compound cursor,
+            # which is exactly the set already delivered by the previous run.
+            if (publication_date, document_number) <= (last_date, last_document):
+                continue
+
+            flattened = flatten_document(record)
+
+            # The 'upsert' operation is used to insert or update data in the destination table.
+            # The first argument is the name of the destination table.
+            # The second argument is a dictionary containing the record to be upserted.
+            op.upsert(table="document", data=flattened)
+
+            record_count += 1
+            cursor_date = publication_date
+            cursor_document = document_number
+
+            if record_count % __CHECKPOINT_INTERVAL == 0:
+                # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
+                # from the correct position in case of next sync or interruptions.
+                # You should checkpoint even if you are not using incremental sync, as it tells Fivetran it is safe to write to destination.
+                # For large datasets, checkpoint regularly (e.g., every N records) not only at the end.
+                # Learn more about how and where to checkpoint by reading our best practices documentation
+                # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
+                op.checkpoint(
+                    state={
+                        "last_publication_date": cursor_date,
+                        "last_document_number": cursor_document,
+                    }
+                )
+                log.info(
+                    f"Checkpointed after {record_count} records at "
+                    f"{cursor_date}/{cursor_document}"
+                )
+
+            # The compound cursor makes max_records_per_sync a true ceiling:
+            # because document_number uniquely orders documents within a day, the
+            # run can stop on any single record and the next sync resumes on the
+            # very next one. There is no timestamp-group overshoot to accommodate.
+            if max_records and record_count >= max_records:
+                log.warning(
+                    f"Reached the configured max_records_per_sync limit of {max_records}. "
+                    f"Synced {record_count} records through {cursor_date}/{cursor_document}. "
+                    f"The next sync resumes immediately after it."
+                )
+                limit_reached = True
+                break
+
+        if limit_reached:
+            break
+
+        # Follow the API's own pagination link, which carries a search_after
+        # cursor for stable deep pagination. The walk terminates when the link is
+        # absent.
+        url = response.get("next_page_url")
+
+    # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
+    # from the correct position in case of next sync or interruptions.
+    # You should checkpoint even if you are not using incremental sync, as it tells Fivetran it is safe to write to destination.
+    # For large datasets, checkpoint regularly (e.g., every N records) not only at the end.
+    # Learn more about how and where to checkpoint by reading our best practices documentation
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
+    op.checkpoint(
+        state={
+            "last_publication_date": cursor_date,
+            "last_document_number": cursor_document,
+        }
+    )
+
+    log.info(
+        f"Sync complete. Upserted {record_count} documents up to "
+        f"{cursor_date}/{cursor_document}"
+    )
+
+
+connector = Connector(update=update, schema=schema)
+
+if __name__ == "__main__":
+    with open("configuration.json", "r") as f:
+        configuration = json.load(f)
+    connector.debug(configuration=configuration)

--- a/federal_register/connector.py
+++ b/federal_register/connector.py
@@ -269,7 +269,7 @@ def update(configuration: dict, state: dict):
         state: A dictionary containing state information from previous runs
         The state dictionary is empty for the first sync or for any full re-sync
     """
-    log.warning("Example: Source Examples - Federal Register Documents")
+    log.warning("Example: Source Examples : Federal Register Documents")
 
     validate_configuration(configuration=configuration)
 

--- a/federal_register/connector.py
+++ b/federal_register/connector.py
@@ -315,6 +315,15 @@ def update(configuration: dict, state: dict):
                 log.warning("Skipping a record with no document_number")
                 continue
 
+            # Same treatment for publication_date, and for a sharper reason: it is
+            # half of the compound cursor below, and `None <= "2024-01-02"` raises
+            # TypeError -- so a single null would abort the entire sync rather than
+            # skipping one record. It is also checkpointed into state, where a null
+            # would poison the cursor for every later run.
+            if not publication_date:
+                log.warning(f"Skipping record {document_number} with no publication_date")
+                continue
+
             # The lower bound is inclusive, so a resume re-requests the last
             # synced day. Skip any document at or before the compound cursor,
             # which is exactly the set already delivered by the previous run.

--- a/federal_register/connector.py
+++ b/federal_register/connector.py
@@ -339,12 +339,9 @@ def update(configuration: dict, state: dict):
                 # For large datasets, checkpoint regularly (e.g., every N records) not only at the end.
                 # Learn more about how and where to checkpoint by reading our best practices documentation
                 # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
-                op.checkpoint(
-                    state={
-                        "last_publication_date": cursor_date,
-                        "last_document_number": cursor_document,
-                    }
-                )
+                state["last_publication_date"] = cursor_date
+                state["last_document_number"] = cursor_document
+                op.checkpoint(state=state)
                 log.info(
                     f"Checkpointed after {record_count} records at "
                     f"{cursor_date}/{cursor_document}"
@@ -377,12 +374,9 @@ def update(configuration: dict, state: dict):
     # For large datasets, checkpoint regularly (e.g., every N records) not only at the end.
     # Learn more about how and where to checkpoint by reading our best practices documentation
     # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
-    op.checkpoint(
-        state={
-            "last_publication_date": cursor_date,
-            "last_document_number": cursor_document,
-        }
-    )
+    state["last_publication_date"] = cursor_date
+    state["last_document_number"] = cursor_document
+    op.checkpoint(state=state)
 
     log.info(
         f"Sync complete. Upserted {record_count} documents up to "
@@ -390,9 +384,23 @@ def update(configuration: dict, state: dict):
     )
 
 
+# Create the connector object using the schema and update functions
 connector = Connector(update=update, schema=schema)
 
+# Check if the script is being run as the main module.
+# This is Python's standard entry method allowing your script to be run directly from the command line or IDE 'run' button.
+#
+# IMPORTANT: The recommended way to test your connector is using the Fivetran debug command:
+#   fivetran debug
+#
+# This local testing block is provided as a convenience for quick debugging during development,
+# such as using IDE debug tools (breakpoints, step-through debugging, etc.).
+# Note: This method is not called by Fivetran when executing your connector in production.
+# Always test using 'fivetran debug' prior to finalizing and deploying your connector.
 if __name__ == "__main__":
+    # Open the configuration.json file and load its contents
     with open("configuration.json", "r") as f:
         configuration = json.load(f)
+
+    # Test the connector locally
     connector.debug(configuration=configuration)

--- a/federal_register/tests/test_connector.py
+++ b/federal_register/tests/test_connector.py
@@ -1,0 +1,408 @@
+"""Tests for the Federal Register documents connector.
+
+These target the hazards found while profiling the live API on 2026-07-29, not
+generic coverage. The universal rules are inherited from the shared contract; the
+functions below are what is specific to this source:
+
+  - publication_date[gte] is INCLUSIVE and day-granular, and a single day carries
+    dozens of documents. A date-only cursor would re-fetch or skip records, so the
+    cursor is compound: (publication_date, document_number). document_number is the
+    exact value the API sorts on within a day -- its search_after cursor decodes to
+    [publication_date_epoch, document_number] -- so the ordering matches the server.
+  - Because document_number uniquely orders documents within a day, a bounded run
+    can stop on any single record and resume on the next. max_records_per_sync is a
+    TRUE ceiling here, unlike a bare-timestamp cursor where it is a floor.
+  - agencies is a list of objects; flattened to delimited id and name strings.
+  - the API returns pages via next_page_url; the walk stops on its absence.
+
+Run:  ~/venvs/connector-sdk-venv/bin/python -m pytest tests/ -v
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import connector as c  # noqa: E402
+from connector_test_harness import ConnectorContract  # noqa: E402
+
+
+# ----------------------------------------------------- the shared contract
+class TestFederalRegisterContract(ConnectorContract):
+    """Every universal connector rule, inherited rather than re-written."""
+
+    module = c
+    flatten = staticmethod(c.flatten_document)
+    sample_record = None  # set below, after _document() is defined
+    sparse_record = {"document_number": "2024-00001"}
+
+
+# --------------------------------------------------------------- fixtures
+def _document(publication_date="2024-01-02", document_number="2023-26792", **overrides):
+    """Build a minimal API record, shaped like the real documents.json response."""
+    base = {
+        "document_number": document_number,
+        "publication_date": publication_date,
+        "type": "Notice",
+        "title": "Notice of Solicitation of Applications",
+        "abstract": "The Rural Business-Cooperative Service announces the availability of funds.",
+        "excerpts": "The Rural Business-Cooperative Service announces...",
+        "html_url": "https://www.federalregister.gov/documents/2024/01/02/2023-26792/notice",
+        "pdf_url": "https://www.govinfo.gov/content/pkg/FR-2024-01-02/pdf/2023-26792.pdf",
+        "public_inspection_pdf_url": "https://www.federalregister.gov/documents/full_text/pdf/2023-26792.pdf",
+        "agencies": [
+            {
+                "raw_name": "DEPARTMENT OF AGRICULTURE",
+                "name": "Agriculture Department",
+                "id": 12,
+                "url": "https://www.federalregister.gov/agencies/agriculture-department",
+            }
+        ],
+    }
+    base.update(overrides)
+    return base
+
+
+# ----------------------------------------------- nested agency flattening
+def test_agencies_are_flattened_not_stringified():
+    """The trap: agencies is a list of dicts. str() on it type checks, lints, and
+    lands a stringified list in a scalar column."""
+    row = c.flatten_document(
+        _document(
+            agencies=[
+                {
+                    "name": "Agriculture Department",
+                    "raw_name": "DEPARTMENT OF AGRICULTURE",
+                    "id": 12,
+                },
+                {"name": "Forest Service", "raw_name": "Forest Service", "id": 145},
+            ]
+        )
+    )
+    assert row["agency_ids"] == "12,145"
+    assert row["agency_names"] == "Agriculture Department; Forest Service"
+    assert "[" not in row["agency_ids"]
+    assert "{" not in row["agency_names"]
+
+
+def test_empty_agencies_become_null_not_empty_string():
+    row = c.flatten_document(_document(agencies=[]))
+    assert row["agency_ids"] is None
+    assert row["agency_names"] is None
+
+
+def test_agency_name_falls_back_to_raw_name():
+    row = c.flatten_document(_document(agencies=[{"raw_name": "SOME BOARD", "id": 500}]))
+    assert row["agency_names"] == "SOME BOARD"
+    assert row["agency_ids"] == "500"
+
+
+def test_agency_without_id_is_skipped_in_ids_only():
+    row = c.flatten_document(_document(agencies=[{"name": "A", "id": 1}, {"name": "B"}]))
+    assert row["agency_ids"] == "1"
+    assert row["agency_names"] == "A; B"
+
+
+# ----------------------------------------------- reserved-word rename (#8)
+def test_type_is_renamed_to_document_type():
+    """The API field is `type`. It is emitted as `document_type` because `type`
+    reads ambiguously as a column and some warehouses refuse it as an identifier.
+    The raw key must never reach the schema."""
+    row = c.flatten_document(_document(type="Rule"))
+    assert row["document_type"] == "Rule"
+    assert "type" not in row
+
+
+# ----------------------------------------------------------- URL building
+def test_url_uses_inclusive_gte_oldest_order_and_pinned_fields():
+    url = c.build_initial_url("2024-01-02", 100)
+    assert "conditions%5Bpublication_date%5D%5Bgte%5D=2024-01-02" in url
+    assert "order=oldest" in url
+    assert "per_page=100" in url
+    assert "fields%5B%5D=document_number" in url
+
+
+# ----------------------------------------------------------- configuration
+@pytest.mark.parametrize(
+    "config",
+    [
+        {"page_size": "0"},
+        {"page_size": "1001"},
+        {"page_size": "abc"},
+        {"max_records_per_sync": "-1"},
+        {"max_records_per_sync": "lots"},
+        {"initial_sync_start_date": "2024/01/02"},
+        {"initial_sync_start_date": "not-a-date"},
+    ],
+)
+def test_invalid_configuration_fails_fast(config):
+    """Fail at configuration time, not as an HTTP error midway through a sync."""
+    with pytest.raises(ValueError):
+        c.validate_configuration(config)
+
+
+def test_valid_and_empty_configurations_pass():
+    c.validate_configuration({})  # every field is optional with a default
+    c.validate_configuration(
+        {
+            "page_size": "1000",
+            "max_records_per_sync": "500",
+            "initial_sync_start_date": "2024-01-02",
+        }
+    )
+
+
+# --------------------------------------------------------- sync behaviour
+def test_cursor_walk_terminates_on_missing_next_page_url():
+    """The walk stops when next_page_url is absent, not when a page is empty."""
+    pages = [
+        {"results": [_document()], "next_page_url": "u2"},
+        {"results": [], "next_page_url": None},  # link absent -> stop
+    ]
+    with patch.object(c, "get_api_response", side_effect=pages) as api, patch.object(
+        c.op, "upsert"
+    ) as upsert, patch.object(c.op, "checkpoint"):
+        c.update({}, {})
+    assert api.call_count == 2
+    assert upsert.call_count == 1
+
+
+def test_inclusive_boundary_records_already_synced_are_skipped():
+    """The gte lower bound re-serves the last synced day on resume. Documents at
+    or before the compound cursor are exactly the ones already delivered."""
+    page = {
+        "results": [
+            _document("2024-01-02", "2023-26792"),  # <= cursor, skip
+            _document("2024-01-02", "2023-27783"),  # == cursor, skip
+            _document("2024-01-02", "2023-27901"),  # > cursor, emit
+            _document("2024-01-03", "2023-28000"),  # next day, emit
+        ],
+        "next_page_url": None,
+    }
+    state = {
+        "last_publication_date": "2024-01-02",
+        "last_document_number": "2023-27783",
+    }
+    with patch.object(c, "get_api_response", return_value=page), patch.object(
+        c.op, "upsert"
+    ) as upsert, patch.object(c.op, "checkpoint"):
+        c.update({}, state)
+    emitted = [x.kwargs["data"]["document_number"] for x in upsert.call_args_list]
+    assert emitted == ["2023-27901", "2023-28000"]
+
+
+def test_compound_cursor_resumes_mid_boundary_day():
+    """The named boundary guard.
+
+    An inclusive, day-granular lower bound with dozens of documents per day would
+    deadlock a bare-timestamp cursor: a per-sync cap that stops mid-day would
+    checkpoint that day, and the next sync would reopen it and stop in the same
+    place forever. The compound (publication_date, document_number) cursor stops
+    BETWEEN two documents on the same day and resumes on the next one.
+    """
+    day = [_document("2024-01-02", f"2023-{n:05d}") for n in range(26792, 26796)]  # 4 docs
+
+    # Run 1: cap of 2 stops mid-day after the first two documents.
+    page = {"results": list(day), "next_page_url": None}
+    with patch.object(c, "get_api_response", return_value=page), patch.object(
+        c.op, "upsert"
+    ) as upsert, patch.object(c.op, "checkpoint") as checkpoint:
+        c.update({"max_records_per_sync": "2"}, {})
+    run1 = [x.kwargs["data"]["document_number"] for x in upsert.call_args_list]
+    assert run1 == ["2023-26792", "2023-26793"]
+    state = checkpoint.call_args.kwargs["state"]
+    assert state == {
+        "last_publication_date": "2024-01-02",
+        "last_document_number": "2023-26793",
+    }
+
+    # Run 2: the inclusive bound re-serves the same day; the compound cursor skips
+    # the two already delivered and resumes on the third, same day.
+    with patch.object(c, "get_api_response", return_value=page), patch.object(
+        c.op, "upsert"
+    ) as upsert, patch.object(c.op, "checkpoint") as checkpoint:
+        c.update({"max_records_per_sync": "2"}, state)
+    run2 = [x.kwargs["data"]["document_number"] for x in upsert.call_args_list]
+    assert run2 == ["2023-26794", "2023-26795"]
+
+
+def test_max_records_is_a_true_ceiling_not_a_floor():
+    """Because document_number uniquely orders a day, the cap stops on the exact
+    record, not at the end of a group. Three documents, cap of 2, delivers two."""
+    page = {
+        "results": [
+            _document("2024-01-02", "2023-26792"),
+            _document("2024-01-02", "2023-26793"),
+            _document("2024-01-02", "2023-26794"),
+        ],
+        "next_page_url": None,
+    }
+    with patch.object(c, "get_api_response", return_value=page), patch.object(
+        c.op, "upsert"
+    ) as upsert, patch.object(c.op, "checkpoint") as checkpoint:
+        c.update({"max_records_per_sync": "2"}, {})
+    assert upsert.call_count == 2
+    assert checkpoint.call_args.kwargs["state"] == {
+        "last_publication_date": "2024-01-02",
+        "last_document_number": "2023-26793",
+    }
+
+
+def test_repeated_syncs_drain_all_records_without_duplication():
+    """Repeated bounded syncs cover every document exactly once and the cursor
+    never regresses -- the compound-cursor equivalent of a drain test."""
+    all_docs = (
+        [_document("2024-01-02", f"2023-{n:05d}") for n in range(1, 4)]
+        + [_document("2024-01-03", f"2023-{n:05d}") for n in range(4, 7)]
+        + [_document("2024-01-04", f"2023-{n:05d}") for n in range(7, 10)]
+    )
+
+    def key(doc):
+        return (doc["publication_date"], doc["document_number"])
+
+    cursors, delivered = [], []
+    state = {}
+    for _ in range(5):
+        last = (
+            state.get("last_publication_date", "2024-01-02"),
+            state.get("last_document_number", ""),
+        )
+        # The gte filter re-serves from the cursor's day onward; the connector
+        # itself skips anything at or before the compound cursor.
+        window = {
+            "results": [d for d in all_docs if d["publication_date"] >= last[0]],
+            "next_page_url": None,
+        }
+        with patch.object(c, "get_api_response", return_value=window), patch.object(
+            c.op, "upsert"
+        ) as upsert, patch.object(c.op, "checkpoint") as checkpoint:
+            c.update({"max_records_per_sync": "2"}, state)
+        delivered += [x.kwargs["data"]["document_number"] for x in upsert.call_args_list]
+        state = checkpoint.call_args.kwargs["state"]
+        cursors.append((state["last_publication_date"], state["last_document_number"]))
+
+    assert cursors == sorted(cursors), f"cursor moved backwards: {cursors}"
+    assert len(delivered) == len(set(delivered)) == 9, f"dup or missing: {delivered}"
+
+
+def test_state_never_moves_backwards_on_an_empty_window():
+    """An empty sync must re-checkpoint the SAME cursor rather than reset it."""
+    with patch.object(
+        c, "get_api_response", return_value={"results": [], "next_page_url": None}
+    ), patch.object(c.op, "upsert"), patch.object(c.op, "checkpoint") as checkpoint:
+        c.update(
+            {},
+            {
+                "last_publication_date": "2024-01-02",
+                "last_document_number": "2023-27901",
+            },
+        )
+    assert checkpoint.call_args.kwargs["state"] == {
+        "last_publication_date": "2024-01-02",
+        "last_document_number": "2023-27901",
+    }
+
+
+def test_record_without_document_number_is_skipped():
+    page = {
+        "results": [{"publication_date": "2024-01-02", "type": "Notice"}, _document()],
+        "next_page_url": None,
+    }
+    with patch.object(c, "get_api_response", return_value=page), patch.object(
+        c.op, "upsert"
+    ) as upsert, patch.object(c.op, "checkpoint"):
+        c.update({}, {})
+    assert upsert.call_count == 1
+
+
+def test_record_without_publication_date_is_skipped():
+    """A null publication_date must not reach the compound-cursor comparison.
+
+    Raised by fivetran-ankitsilla on PR #55. It is not a style point: the cursor
+    compares `(publication_date, document_number) <= (last_date, last_document)`,
+    and in Python `None <= "2024-01-02"` raises TypeError -- so ONE record with a
+    null publication_date aborts the whole sync, not just that record. The
+    connector already guards document_number two lines earlier; the omission of
+    its sibling was the bug. The value is also checkpointed into state, so a null
+    that slipped through would poison the cursor for every later run.
+    """
+    page = {
+        "results": [{"document_number": "2024-99999", "type": "Notice"}, _document()],
+        "next_page_url": None,
+    }
+    with patch.object(c, "get_api_response", return_value=page), patch.object(
+        c.op, "upsert"
+    ) as upsert, patch.object(c.op, "checkpoint") as checkpoint:
+        c.update({}, {})
+    # The good record still lands, and the sync does not die on the null one.
+    assert upsert.call_count == 1
+    assert checkpoint.call_args.kwargs["state"]["last_publication_date"] is not None
+
+
+def test_state_advances_to_the_last_document_seen():
+    page = {
+        "results": [
+            _document("2024-01-02", "2023-26792"),
+            _document("2024-01-05", "2024-00123"),
+        ],
+        "next_page_url": None,
+    }
+    with patch.object(c, "get_api_response", return_value=page), patch.object(
+        c.op, "upsert"
+    ), patch.object(c.op, "checkpoint") as checkpoint:
+        c.update({}, {})
+    assert checkpoint.call_args.kwargs["state"] == {
+        "last_publication_date": "2024-01-05",
+        "last_document_number": "2024-00123",
+    }
+
+
+# ------------------------------------------------------------ error handling
+def test_client_error_fails_immediately_without_retrying():
+    """A 400 means the request is wrong. Retrying only delays the failure."""
+    import requests
+
+    response = requests.Response()
+    response.status_code = 400
+    response._content = b'{"errors":[{"detail":"bad request"}]}'
+    with patch.object(c.requests, "get", return_value=response) as get, patch.object(
+        c.time, "sleep"
+    ) as sleep:
+        with pytest.raises(RuntimeError, match="rejected the request"):
+            c.get_api_response("https://example.invalid")
+    assert get.call_count == 1
+    assert sleep.call_count == 0
+
+
+def test_transient_error_retries_then_succeeds():
+    import requests
+
+    ok = requests.Response()
+    ok.status_code = 200
+    ok._content = b'{"results":[]}'
+    with patch.object(
+        c.requests,
+        "get",
+        side_effect=[requests.exceptions.ConnectionError("reset"), ok],
+    ) as get, patch.object(c.time, "sleep") as sleep:
+        assert c.get_api_response("https://example.invalid") == {"results": []}
+    assert get.call_count == 2
+    assert sleep.call_count == 1
+
+
+def test_retries_are_bounded_and_raise():
+    import requests
+
+    with patch.object(
+        c.requests, "get", side_effect=requests.exceptions.ConnectionError("down")
+    ) as get, patch.object(c.time, "sleep"):
+        with pytest.raises(RuntimeError, match="after 3 attempts"):
+            c.get_api_response("https://example.invalid")
+    assert get.call_count == c.__MAX_RETRIES
+
+
+# The contract needs a realistic record; _document() is defined above.
+TestFederalRegisterContract.sample_record = _document()

--- a/federal_register/tests/test_connector.py
+++ b/federal_register/tests/test_connector.py
@@ -254,11 +254,17 @@ def test_max_records_is_a_true_ceiling_not_a_floor():
 def test_repeated_syncs_drain_all_records_without_duplication():
     """Repeated bounded syncs cover every document exactly once and the cursor
     never regresses -- the compound-cursor equivalent of a drain test."""
-    all_docs = (
-        [_document("2024-01-02", f"2023-{n:05d}") for n in range(1, 4)]
-        + [_document("2024-01-03", f"2023-{n:05d}") for n in range(4, 7)]
-        + [_document("2024-01-04", f"2023-{n:05d}") for n in range(7, 10)]
-    )
+    # Built as one comprehension over (date, span) pairs rather than three lists
+    # joined with `+`. Black splits a multi-line binary expression with the operator
+    # at the START of each line, and repo CI selects W (W503: line break before
+    # binary operator) -- so the two tools fight over that shape and CI loses.
+    # No operator split, nothing to disagree about.
+    spans = [
+        ("2024-01-02", range(1, 4)),
+        ("2024-01-03", range(4, 7)),
+        ("2024-01-04", range(7, 10)),
+    ]
+    all_docs = [_document(date, f"2023-{n:05d}") for date, span in spans for n in span]
 
     def key(doc):
         return (doc["publication_date"], doc["document_number"])


### PR DESCRIPTION
## What this connector does

Syncs documents from the public [Federal Register API](https://www.federalregister.gov/developers/documentation/api/v1) into a single `document` table keyed on `document_number`. The Federal Register is the official daily journal of the US government (rules, proposed rules, notices, presidential documents). The API is public and requires no credentials.

## Hazards found while profiling the live API (2026-07-29)

Profiling was done against the live endpoint before any code was written. What it found:

- Hazard #1 -- inclusive range to compound cursor (the one exercised). `conditions[publication_date][gte]` is inclusive and `publication_date` is day-granular, and a single day carries dozens of documents (65 on 2024-01-02). A date-only cursor would either re-fetch a whole day every sync or skip records. Handled with a compound `(publication_date, document_number)` cursor. `document_number` is the exact value the API sorts on within a day -- its `next_page_url` carries a `search_after` cursor that decodes to `[publication_date_epoch, document_number]` -- so the connector's ordering matches the server's. Because the tiebreaker is unique, `max_records_per_sync` is a TRUE ceiling: a bounded run stops on an exact record and the next run resumes on the following one, with no timestamp-group overshoot.
- Nested arrays (#3, incidental). `agencies` is a list of objects; flattened to `agency_ids` and `agency_names` delimited strings, with empty lists stored as null.
- `type` field. Delivered as `document_type`. Note: `type` is not in the harness's reserved-keyword list, so this connector does not strictly exercise hazard #8 (GBIF, week 3, is the designated #8 week). The rename is defensive -- `type` reads ambiguously as a column and some warehouses refuse it as an identifier.
- Offset/window cap (#2) -- checked and NOT reproduced. `page=10, per_page=1000` (10k rows deep) returned HTTP 200 with full results, so there is no hard page-window cap on this API. The connector follows `next_page_url` (search_after) regardless, which is the correct choice for a mutable, append-heavy dataset.
- No explicit rate-limit headers; transient failures and 429s are retried with exponential backoff, and 4xx client errors fail immediately.

## Debug evidence

Two live `fivetran debug` runs. The second resumes from the first's checkpoint rather than restarting:

```
================================================================================
DEBUG RUN 1 of 2 — fresh sync (no prior state)
command: fivetran debug --configuration configuration_local.json
config:  initial_sync_start_date=2024-01-02, page_size=100, max_records_per_sync=150
================================================================================
29-Jul 16:41:24.755 INFO  › debugging connector at: .../contributions/federal_register
29-Jul 16:41:26.724 INFO  previous state:
{}
29-Jul 16:41:27.923 INFO  calling schema()
29-Jul 16:41:27.934 INFO  schema change detected: tester.document
29-Jul 16:41:27.939 INFO  table created: tester.document
29-Jul 16:41:27.945 INFO  calling update()
29-Jul 16:41:27.945 WARNING Example: Source Examples - Federal Register Documents
29-Jul 16:41:27.946 INFO  Syncing Federal Register documents published on or after 2024-01-02 (page size 100, record limit 150)
29-Jul 16:41:28.785 WARNING Reached the configured max_records_per_sync limit of 150. Synced 150 records through 2024-01-03/2023-28936. The next sync resumes immediately after it.
29-Jul 16:41:28.789 INFO  Sync complete. Upserted 150 documents up to 2024-01-03/2023-28936
29-Jul 16:41:29.023 INFO  checkpoint recorded: {"last_publication_date": "2024-01-03", "last_document_number": "2023-28936"}
29-Jul 16:41:29.024 INFO  Final checkpoint: committing any remaining operations
29-Jul 16:41:29.024 INFO  SYNC SUCCEEDED — total elapsed 00:00:02
Operation       | Counts
----------------+------------
Upserts         | 150
Updates         | 0
Deletes         | 0
Truncates       | 0
Schema changes  | 1
Checkpoints     | 1
29-Jul 16:41:30.341 INFO  peak memory used by the debug process: 0.05 GB


================================================================================
DEBUG RUN 2 of 2 — RESUME (reads run 1 checkpoint from files/state.json)
command: fivetran debug --configuration configuration_local.json
================================================================================
29-Jul 16:41:44.965 INFO  › debugging connector at: .../contributions/federal_register
29-Jul 16:41:46.442 INFO  previous state:
{"last_publication_date": "2024-01-03", "last_document_number": "2023-28936"}
29-Jul 16:41:47.594 INFO  calling schema()
29-Jul 16:41:47.615 INFO  calling update()
29-Jul 16:41:47.615 WARNING Example: Source Examples - Federal Register Documents
29-Jul 16:41:47.616 INFO  Syncing Federal Register documents published on or after 2024-01-03 (page size 100, record limit 150)
29-Jul 16:41:48.582 WARNING Reached the configured max_records_per_sync limit of 150. Synced 150 records through 2024-01-05/2024-00065. The next sync resumes immediately after it.
29-Jul 16:41:48.588 INFO  Sync complete. Upserted 150 documents up to 2024-01-05/2024-00065
29-Jul 16:41:48.801 INFO  checkpoint recorded: {"last_publication_date": "2024-01-05", "last_document_number": "2024-00065"}
29-Jul 16:41:48.802 INFO  Final checkpoint: committing any remaining operations
29-Jul 16:41:48.802 INFO  SYNC SUCCEEDED — total elapsed 00:00:02
Operation       | Counts
----------------+------------
Upserts         | 150
Updates         | 0
Deletes         | 0
Truncates       | 0
Schema changes  | 1
Checkpoints     | 1
29-Jul 16:41:50.139 INFO  peak memory used by the debug process: 0.05 GB

--------------------------------------------------------------------------------
RESUME PROOF: run 1 checkpointed at 2024-01-03/2023-28936; run 2 loaded that as
its previous state, synced FROM 2024-01-03 (not from the 2024-01-02 config start),
and advanced the cursor to 2024-01-05/2024-00065. The second run resumed; it did
not restart.
--------------------------------------------------------------------------------

```

## Checklist

- SDK v2+ (`op.upsert` / `op.checkpoint` called directly, no `yield op.`)
- `validate_configuration()` called first in `update()`
- `configuration.json` holds placeholder values only; no credentials in the diff
- Public API, no authentication
- Passes the shared connector contract (universal rules) plus source-specific tests for the compound cursor, inclusive-boundary skip, agency flattening, and pagination termination
- 8-stage pre-submission gate passed (flake8, black --line-length=99, credential scrub)
- Ships three files: `connector.py`, `configuration.json`, `README.md`
