### PR TITLE
feature(connectors): add GBIF occurrences connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ For SDK installation and setup, visit the main [Fivetran Connector SDK repositor
 - **[elastic_email](https://github.com/fivetran/community_connectors/tree/main/elastic_email)** - Sync email marketing data from Elastic Email
 - **[fleetio](https://github.com/fivetran/community_connectors/tree/main/fleetio)** - Sync fleet management data from Fleetio
 - **[fred](https://github.com/fivetran/community_connectors/tree/main/fred)** - Sync economic data from Federal Reserve Economic Data (FRED)
+- **[gbif](https://github.com/fivetran/community_connectors/tree/main/gbif)** - Sync species occurrence records from the GBIF (Global Biodiversity Information Facility) API
 - **[github](https://github.com/fivetran/community_connectors/tree/main/github)** - Sync repository data, commits, and pull requests from GitHub
 - **[github_traffic](https://github.com/fivetran/community_connectors/tree/main/github_traffic)** - Sync GitHub repository traffic data
 - **[gnews](https://github.com/fivetran/community_connectors/tree/main/gnews)** - Sync news articles from GNews API

--- a/gbif/README.md
+++ b/gbif/README.md
@@ -1,0 +1,135 @@
+# GBIF Occurrence Connector Example
+
+## Connector overview
+
+This connector syncs species occurrence records from the [GBIF (Global Biodiversity Information Facility) occurrence search API](https://techdocs.gbif.org/en/openapi/v1/occurrence) into a Fivetran destination. GBIF aggregates biodiversity data from thousands of institutions worldwide: each occurrence record is one observation or specimen of a species at a place and time, carrying its full taxonomic classification, coordinates, event date, and the dataset and institution that published it.
+
+The API is public and requires no credentials. Because the full corpus holds several billion occurrences, the connector is designed for a bounded query: optionally filter by taxon and country, page through the result set, and resume where a previous run stopped. Typical uses are building a regional species checklist, tracking observations of a taxon over time, and assembling a biodiversity corpus for analysis.
+
+## Requirements
+
+- [Supported Python versions](https://github.com/fivetran/community_connectors/blob/main/README.md#requirements)
+- Operating system:
+  - Windows: 10 or later (64-bit only)
+  - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
+  - Linux: Distributions such as Ubuntu 20.04 or later, Debian 10 or later, or Amazon Linux 2 or later (arm64 or x86_64)
+
+## Getting started
+
+Refer to the [Connector SDK Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
+
+To initialize a new Connector SDK project using this connector as a starting point, run:
+
+```bash
+fivetran init --template gbif
+```
+
+`fivetran init` initializes a new Connector SDK project by setting up the project structure, configuration files, and a connector you can run immediately with `fivetran debug`. For more information on `fivetran init`, refer to the [Connector SDK `init` documentation](https://fivetran.com/docs/connector-sdk/connector-development-and-configuration/connector-sdk-commands#fivetraninit).
+
+## Features
+
+- Incremental, resumable backfill of a bounded occurrence query. The offset is the resume cursor, so each run continues where the last one stopped rather than restarting.
+- Offset pagination that respects the GBIF deep-paging cap: the connector reads the total match count, warns when it exceeds the reachable limit, and never requests past it.
+- Reserved SQL keywords in the API payload are renamed at the source, so the delivered schema creates cleanly on any warehouse.
+- Configurable record limit per sync. Because the offset advances per record, the limit is a true ceiling: a run stops on an exact record and the next run resumes on the following one.
+- Retry with exponential backoff on transient transport and server errors, and immediate failure on client errors that a retry cannot fix.
+- No credentials required. The GBIF API is public.
+
+## Configuration file
+
+The connector requires no authentication. Every configuration value is optional: supply the filters you want to narrow the query, and the paging controls you want to override.
+
+```
+{
+  "page_size": "<YOUR_PAGE_SIZE>",
+  "max_records_per_sync": "<YOUR_MAX_RECORDS_PER_SYNC>",
+  "taxon_key": "<YOUR_TAXON_KEY>",
+  "country": "<YOUR_COUNTRY_CODE>"
+}
+```
+
+### Configuration parameters
+
+- `page_size` – Occurrences requested per API call, between 1 and 300. Defaults to 300. The API caps any larger value at 300. Refer to `def validate_configuration(configuration: dict)`.
+- `max_records_per_sync` – Upper bound on occurrences upserted in a single sync, where 0 means no limit. Defaults to 0. Because the offset advances per record, the run stops on the exact record that meets the limit and the next sync resumes on the following one.
+- `taxon_key` – Optional GBIF taxon key to restrict occurrences to one taxon, for example `212` for birds (Aves). Leave empty for no taxon filter. Narrowing the query is how you sync a set larger than the deep-paging cap.
+- `country` – Optional ISO 3166-1 alpha-2 country code to restrict occurrences to one country, for example `US`. Leave empty for no country filter.
+
+> Note: Do not add a `requirements.txt` file. This connector depends only on `requests`, which the Fivetran runtime provides.
+
+## Authentication
+
+The GBIF API is public and requires no API key, token, or account. No authentication configuration is needed and the connector sends no credentials.
+
+## Pagination
+
+The connector uses offset pagination. Each request sets an `offset` and a `limit` (the page size), and the offset advances by the number of records actually consumed, so a run stopped mid-page by `max_records_per_sync` resumes on the exact next record rather than skipping the remainder of the page. Refer to `def build_url(offset, page_size, taxon_key, country)`.
+
+> Note: GBIF caps deep pagination at `offset + limit <= 100000`. A request past the cap returns HTTP 400 rather than data. The connector reads the total match `count` from the first page, warns when it exceeds 100,000, stops at the cap, and never issues a request the API would reject. To sync a result set larger than the cap, narrow the query with `taxon_key` or `country` so it fits under it. The walk otherwise terminates when the API reports `endOfRecords`.
+
+## Data handling
+
+Each occurrence is flattened into a single row in the `occurrence` table, keyed on `gbif_id`. Refer to `def flatten_occurrence(record: dict)`.
+
+The API returns the taxonomic rank fields `class` and `order` as top-level keys. Both are reserved SQL keywords that fail an unquoted `CREATE TABLE` on most warehouses, so they are delivered as the columns `taxon_class` and `taxon_order`. The numeric `key` field duplicates `gbifID` and is itself a reserved word, so it is dropped in favour of the string `gbif_id` primary key.
+
+The `recordedBy` field is usually a string but is a list in some datasets. It is coerced to a single delimited string by `def as_text(value)` so a list never lands stringified in a scalar column. Occurrences that arrive without a `gbifID` are skipped and logged, because that value is the primary key, and the offset still advances past them so the next sync does not re-read them.
+
+Incremental state is the offset into the bounded query. GBIF occurrence search exposes no stable modified-time ordering — `lastInterpreted` is rewritten whenever a record is reprocessed — so a time cursor would skip or duplicate records. The offset is a reliable resume point as long as the result ordering is stable for the duration of the backfill, which GBIF guarantees within the deep-paging cap. A sync that returns no records re-checkpoints the existing offset rather than resetting it. Delivery is at-least-once and the primary key makes the repeated upsert idempotent.
+
+## Error handling
+
+Refer to `def get_api_response(url: str)`.
+
+- Transient failures – Connection errors, timeouts, and 5xx responses are retried up to three times with exponential backoff starting at two seconds.
+- Client errors – A 4xx response other than 429 indicates a malformed request, such as an offset past the deep-paging cap. These fail immediately with the response body included, because a retry cannot change the outcome and only delays the error the operator needs to see.
+- Rate limiting – A 429 response is treated as transient and retried with backoff.
+- Configuration errors – Invalid values raise `ValueError` before any request is sent, so a malformed page size, taxon key, or country code fails at the start of the sync rather than midway through it.
+
+## Tables created
+
+The connector creates one table.
+
+`OCCURRENCE`
+
+Primary key: `gbif_id`
+
+| Column | Type | Description |
+| --- | --- | --- |
+| gbif_id | STRING | The stable GBIF occurrence identifier. Primary key. Derived from the API field `gbifID` |
+| dataset_key | STRING | Key of the GBIF dataset that published the record |
+| publishing_country | STRING | Country of the publishing organization |
+| basis_of_record | STRING | How the record was observed, for example PRESERVED_SPECIMEN or HUMAN_OBSERVATION |
+| occurrence_status | STRING | Whether the taxon was present or absent |
+| scientific_name | STRING | Scientific name as interpreted by GBIF |
+| accepted_scientific_name | STRING | Currently accepted scientific name for the taxon |
+| taxon_key | LONG | GBIF taxon key for the interpreted name |
+| kingdom | STRING | Taxonomic kingdom |
+| phylum | STRING | Taxonomic phylum |
+| taxon_class | STRING | Taxonomic class. Renamed from the reserved API field `class` |
+| taxon_order | STRING | Taxonomic order. Renamed from the reserved API field `order` |
+| family | STRING | Taxonomic family |
+| genus | STRING | Taxonomic genus |
+| species | STRING | Species name |
+| taxon_rank | STRING | Rank of the interpreted taxon, for example SPECIES or GENUS |
+| taxonomic_status | STRING | Taxonomic status, for example ACCEPTED or SYNONYM |
+| country_code | STRING | ISO country code where the occurrence was recorded |
+| country | STRING | Country name where the occurrence was recorded |
+| locality | STRING | Free-text locality description |
+| decimal_latitude | DOUBLE | Latitude in decimal degrees, where provided |
+| decimal_longitude | DOUBLE | Longitude in decimal degrees, where provided |
+| event_date | STRING | Date or date range the occurrence was recorded, as reported |
+| event_year | INT | Year of the occurrence event |
+| event_month | INT | Month of the occurrence event |
+| event_day | INT | Day of the occurrence event |
+| recorded_by | STRING | Who recorded the occurrence. A list is delimited into a single string |
+| institution_code | STRING | Code of the holding institution |
+| catalog_number | STRING | Catalog number within the institution |
+| last_interpreted | STRING | Timestamp GBIF last interpreted the record |
+| license | STRING | License under which the record is published |
+
+## Additional considerations
+
+The examples provided are intended as starting points for your own connector development. While we review them for quality and functionality, we cannot guarantee their suitability for your specific use case. Please test thoroughly before deploying to production.
+
+GBIF holds several billion occurrences, and offset pagination can reach only the first 100,000 records of any single query. For anything larger, narrow the query with `taxon_key` or `country`, or run several connections each scoped to a different filter. For a complete bulk export of a very large query, GBIF's asynchronous [Occurrence Download API](https://techdocs.gbif.org/en/openapi/v1/occurrence#/Searching%20occurrences/searchOccurrence) is the better fit; this connector targets bounded, incrementally-synced queries.

--- a/gbif/README.md
+++ b/gbif/README.md
@@ -39,7 +39,7 @@ fivetran init --template gbif
 
 The connector requires no authentication. Every configuration value is optional: supply the filters you want to narrow the query, and the paging controls you want to override.
 
-```
+```json
 {
   "page_size": "<YOUR_PAGE_SIZE>",
   "max_records_per_sync": "<YOUR_MAX_RECORDS_PER_SYNC>",
@@ -47,6 +47,8 @@ The connector requires no authentication. Every configuration value is optional:
   "country": "<YOUR_COUNTRY_CODE>"
 }
 ```
+
+> Note: When submitting connector code as a community connector in the open-source [Community Connector repository](https://github.com/fivetran/community_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ### Configuration parameters
 
@@ -130,6 +132,6 @@ Primary key: `gbif_id`
 
 ## Additional considerations
 
-The examples provided are intended as starting points for your own connector development. While we review them for quality and functionality, we cannot guarantee their suitability for your specific use case. Please test thoroughly before deploying to production.
+The examples provided are intended to help you effectively use Fivetran's Connector SDK. While we've tested the code, Fivetran cannot be held responsible for any unexpected or negative consequences that may arise from using these examples. For inquiries, please reach out to our Support team.
 
 GBIF holds several billion occurrences, and offset pagination can reach only the first 100,000 records of any single query. For anything larger, narrow the query with `taxon_key` or `country`, or run several connections each scoped to a different filter. For a complete bulk export of a very large query, GBIF's asynchronous [Occurrence Download API](https://techdocs.gbif.org/en/openapi/v1/occurrence#/Searching%20occurrences/searchOccurrence) is the better fit; this connector targets bounded, incrementally-synced queries.

--- a/gbif/configuration.json
+++ b/gbif/configuration.json
@@ -1,0 +1,6 @@
+{
+  "page_size": "<YOUR_PAGE_SIZE>",
+  "max_records_per_sync": "<YOUR_MAX_RECORDS_PER_SYNC>",
+  "taxon_key": "<YOUR_TAXON_KEY>",
+  "country": "<YOUR_COUNTRY_CODE>"
+}

--- a/gbif/connector.py
+++ b/gbif/connector.py
@@ -380,7 +380,8 @@ def update(configuration: dict, state: dict):
                 # For large datasets, checkpoint regularly (e.g., every N records) not only at the end.
                 # Learn more about how and where to checkpoint by reading our best practices documentation
                 # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
-                op.checkpoint(state={"offset": offset})
+                state["offset"] = offset
+                op.checkpoint(state=state)
                 log.info(f"Checkpointed after {record_count} records at offset {offset}")
 
             # Because the offset advances per record, max_records_per_sync is a
@@ -415,14 +416,29 @@ def update(configuration: dict, state: dict):
     # For large datasets, checkpoint regularly (e.g., every N records) not only at the end.
     # Learn more about how and where to checkpoint by reading our best practices documentation
     # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
-    op.checkpoint(state={"offset": offset})
+    state["offset"] = offset
+    op.checkpoint(state=state)
 
     log.info(f"Sync complete. Upserted {record_count} occurrences up to offset {offset}")
 
 
+# Create the connector object using the schema and update functions
 connector = Connector(update=update, schema=schema)
 
+# Check if the script is being run as the main module.
+# This is Python's standard entry method allowing your script to be run directly from the command line or IDE 'run' button.
+#
+# IMPORTANT: The recommended way to test your connector is using the Fivetran debug command:
+#   fivetran debug
+#
+# This local testing block is provided as a convenience for quick debugging during development,
+# such as using IDE debug tools (breakpoints, step-through debugging, etc.).
+# Note: This method is not called by Fivetran when executing your connector in production.
+# Always test using 'fivetran debug' prior to finalizing and deploying your connector.
 if __name__ == "__main__":
+    # Open the configuration.json file and load its contents
     with open("configuration.json", "r") as f:
         configuration = json.load(f)
+
+    # Test the connector locally
     connector.debug(configuration=configuration)

--- a/gbif/connector.py
+++ b/gbif/connector.py
@@ -1,0 +1,428 @@
+"""This connector syncs species occurrence records from the GBIF (Global
+Biodiversity Information Facility) occurrence search API to a Fivetran destination.
+See the Technical Reference documentation
+(https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+and the Best Practices documentation
+(https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+"""
+
+# For reading configuration from a JSON file
+import json
+
+# For handling request delays during retries
+import time
+
+# For building query strings safely
+import urllib.parse
+
+# For making HTTP requests to the GBIF API
+import requests
+
+# Import required classes from fivetran_connector_sdk
+from fivetran_connector_sdk import Connector
+
+# For enabling Logs in your connector code
+from fivetran_connector_sdk import Logging as log
+
+# For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
+from fivetran_connector_sdk import Operations as op
+
+# Base URL for the GBIF occurrence search API.
+__BASE_URL = "https://api.gbif.org/v1/occurrence/search"
+
+# Maximum page size the GBIF occurrence search API accepts. Requesting more is
+# silently capped by the API to this value.
+__MAX_PAGE_SIZE = 300
+
+# Default page size when none is configured.
+__DEFAULT_PAGE_SIZE = 300
+
+# GBIF caps deep pagination: offset + limit must be <= 100000. A request past it
+# returns HTTP 400 rather than data, so the connector must stop at the cap and
+# tell the operator to narrow the query rather than silently skip everything
+# beyond it. Verified live 2026-07-29: offset=100001 returned HTTP 400.
+__OFFSET_CAP = 100000
+
+# Maximum number of retry attempts for API requests.
+__MAX_RETRIES = 3
+
+# Base delay in seconds for exponential backoff retries.
+__BASE_DELAY_SECONDS = 2
+
+# Timeout in seconds for HTTP requests.
+__REQUEST_TIMEOUT_SECONDS = 60
+
+# Number of records processed between checkpoints.
+__CHECKPOINT_INTERVAL = 1000
+
+
+def validate_configuration(configuration: dict):
+    """
+    Validate the configuration dictionary to ensure it contains all required parameters.
+    This function is called at the start of the update method to ensure that the connector has
+    all necessary configuration values.
+    Args:
+        configuration: a dictionary that holds the configuration settings for the connector.
+    Raises:
+        ValueError: if any configuration parameter is missing, malformed, or out of range.
+    """
+    # The GBIF occurrence API requires no authentication, so there are no
+    # required secrets. Every value below is optional, but any value that IS
+    # supplied must be usable -- a malformed page size or country code should
+    # fail here, at configuration time, rather than as an HTTP error midway
+    # through a sync.
+    page_size = configuration.get("page_size", str(__DEFAULT_PAGE_SIZE))
+    if not str(page_size).isdigit() or not 1 <= int(page_size) <= __MAX_PAGE_SIZE:
+        raise ValueError(
+            f"Invalid configuration value for page_size: {page_size}. "
+            f"Must be an integer between 1 and {__MAX_PAGE_SIZE}."
+        )
+
+    max_records = configuration.get("max_records_per_sync", "0")
+    if not str(max_records).isdigit():
+        raise ValueError(
+            f"Invalid configuration value for max_records_per_sync: {max_records}. "
+            "Must be a non-negative integer, where 0 means no limit."
+        )
+
+    taxon_key = configuration.get("taxon_key", "").strip()
+    if taxon_key and (not taxon_key.isdigit() or int(taxon_key) <= 0):
+        raise ValueError(
+            f"Invalid configuration value for taxon_key: {taxon_key}. "
+            "Must be a positive integer GBIF taxon key, for example 212 for birds."
+        )
+
+    country = configuration.get("country", "").strip()
+    if country and not re_two_letter(country):
+        raise ValueError(
+            f"Invalid configuration value for country: {country}. "
+            "Must be a two-letter ISO 3166-1 alpha-2 code, for example US."
+        )
+
+
+def re_two_letter(value: str):
+    """
+    Return True when the value is exactly two ASCII letters.
+    Kept as a small helper so the country check reads clearly and stays testable.
+    Args:
+        value: the candidate country code.
+    Returns:
+        True if the value is two ASCII letters, otherwise False.
+    """
+    return len(value) == 2 and value.isalpha() and value.isascii()
+
+
+def schema(configuration: dict):
+    """
+    Define the schema function which lets you configure the schema your connector delivers.
+    See the technical reference documentation for more details on the schema function:
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
+    Args:
+        configuration: a dictionary that holds the configuration settings for the connector.
+    """
+    return [
+        {
+            "table": "occurrence",
+            "primary_key": ["gbif_id"],
+            "columns": {
+                "gbif_id": "STRING",
+                "dataset_key": "STRING",
+                "publishing_country": "STRING",
+                "basis_of_record": "STRING",
+                "occurrence_status": "STRING",
+                "scientific_name": "STRING",
+                "accepted_scientific_name": "STRING",
+                "taxon_key": "LONG",
+                "kingdom": "STRING",
+                "phylum": "STRING",
+                # The API fields 'class' and 'order' are reserved SQL keywords and
+                # fail an unquoted CREATE TABLE on most warehouses, so they are
+                # renamed at the source to taxon_class and taxon_order.
+                "taxon_class": "STRING",
+                "taxon_order": "STRING",
+                "family": "STRING",
+                "genus": "STRING",
+                "species": "STRING",
+                "taxon_rank": "STRING",
+                "taxonomic_status": "STRING",
+                "country_code": "STRING",
+                "country": "STRING",
+                "locality": "STRING",
+                "decimal_latitude": "DOUBLE",
+                "decimal_longitude": "DOUBLE",
+                "event_date": "STRING",
+                "event_year": "INT",
+                "event_month": "INT",
+                "event_day": "INT",
+                "recorded_by": "STRING",
+                "institution_code": "STRING",
+                "catalog_number": "STRING",
+                "last_interpreted": "STRING",
+                "license": "STRING",
+            },
+        }
+    ]
+
+
+def as_text(value):
+    """
+    Coerce a value that the API may return as either a scalar or a list into a
+    single scalar string, so a list never lands stringified in a scalar column.
+    Args:
+        value: a scalar, a list, or None.
+    Returns:
+        A delimited string for a non-empty list, the value unchanged for a
+        scalar, or None when there is nothing to store.
+    """
+    if isinstance(value, list):
+        parts = [str(item) for item in value if item is not None]
+        return "; ".join(parts) if parts else None
+    return value
+
+
+def get_api_response(url: str):
+    """
+    Send a GET request to the GBIF API and return the decoded JSON response.
+    Retries on transient transport and server errors with exponential backoff.
+    Args:
+        url: the fully-qualified request URL, including any query string.
+    Returns:
+        The decoded JSON response body as a dictionary.
+    Raises:
+        RuntimeError: if the API cannot be reached successfully within the retry budget.
+    """
+    last_error = None
+    for attempt in range(__MAX_RETRIES):
+        try:
+            response = requests.get(url, timeout=__REQUEST_TIMEOUT_SECONDS)
+
+            # A 4xx other than 429 means the request itself is wrong -- a bad
+            # filter or an offset past the deep-paging cap. Retrying cannot fix
+            # it and only delays a failure the operator needs to see, so fail
+            # immediately.
+            if 400 <= response.status_code < 500 and response.status_code != 429:
+                raise RuntimeError(
+                    f"GBIF API rejected the request with HTTP "
+                    f"{response.status_code}: {response.text[:500]}"
+                )
+
+            response.raise_for_status()
+            return response.json()
+        except (requests.exceptions.RequestException, ValueError) as error:
+            last_error = error
+            if attempt < __MAX_RETRIES - 1:
+                delay = __BASE_DELAY_SECONDS * (2**attempt)
+                log.warning(
+                    f"GBIF API request failed (attempt {attempt + 1} of "
+                    f"{__MAX_RETRIES}), retrying in {delay}s: {error}"
+                )
+                time.sleep(delay)
+
+    raise RuntimeError(f"GBIF API request failed after {__MAX_RETRIES} attempts: {last_error}")
+
+
+def build_url(offset: int, page_size: int, taxon_key: str, country: str):
+    """
+    Build a request URL for the occurrence search at a given offset.
+    Args:
+        offset: the number of records to skip, which doubles as the resume cursor.
+        page_size: number of records to request in this page.
+        taxon_key: optional GBIF taxon key filter, or an empty string.
+        country: optional ISO 3166-1 alpha-2 country filter, or an empty string.
+    Returns:
+        The fully-qualified URL for the requested page.
+    """
+    # urlencode encodes every value, so no config-derived filter reaches the URL
+    # unescaped.
+    query = [("offset", str(offset)), ("limit", str(page_size))]
+    if taxon_key:
+        query.append(("taxonKey", taxon_key))
+    if country:
+        query.append(("country", country.upper()))
+    return f"{__BASE_URL}?{urllib.parse.urlencode(query)}"
+
+
+def flatten_occurrence(record: dict):
+    """
+    Flatten one GBIF occurrence record into a single destination row.
+    Args:
+        record: one element of the API response "results" array.
+    Returns:
+        A dictionary whose keys match the occurrence table columns.
+    """
+    gbif_id = record.get("gbifID")
+
+    return {
+        "gbif_id": str(gbif_id) if gbif_id is not None else None,
+        "dataset_key": record.get("datasetKey"),
+        "publishing_country": record.get("publishingCountry"),
+        "basis_of_record": record.get("basisOfRecord"),
+        "occurrence_status": record.get("occurrenceStatus"),
+        "scientific_name": record.get("scientificName"),
+        "accepted_scientific_name": record.get("acceptedScientificName"),
+        "taxon_key": record.get("taxonKey"),
+        "kingdom": record.get("kingdom"),
+        "phylum": record.get("phylum"),
+        # 'class' and 'order' are reserved SQL keywords; they are delivered under
+        # non-colliding names so an unquoted CREATE TABLE cannot fail on them.
+        "taxon_class": record.get("class"),
+        "taxon_order": record.get("order"),
+        "family": record.get("family"),
+        "genus": record.get("genus"),
+        "species": record.get("species"),
+        "taxon_rank": record.get("taxonRank"),
+        "taxonomic_status": record.get("taxonomicStatus"),
+        "country_code": record.get("countryCode"),
+        "country": record.get("country"),
+        "locality": record.get("locality"),
+        "decimal_latitude": record.get("decimalLatitude"),
+        "decimal_longitude": record.get("decimalLongitude"),
+        "event_date": as_text(record.get("eventDate")),
+        "event_year": record.get("year"),
+        "event_month": record.get("month"),
+        "event_day": record.get("day"),
+        # recordedBy is usually a string but is a list in some datasets; coerce
+        # so a list never lands stringified in a scalar column.
+        "recorded_by": as_text(record.get("recordedBy")),
+        "institution_code": record.get("institutionCode"),
+        "catalog_number": record.get("catalogNumber"),
+        "last_interpreted": record.get("lastInterpreted"),
+        "license": record.get("license"),
+    }
+
+
+def update(configuration: dict, state: dict):
+    """
+    Define the update function, which is a required function, and is called by Fivetran during each sync.
+    See the technical reference documentation for more details on the update function
+    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    Args:
+        configuration: A dictionary containing connection details
+        state: A dictionary containing state information from previous runs
+        The state dictionary is empty for the first sync or for any full re-sync
+    """
+    log.warning("Example: Source Examples - GBIF Occurrences")
+
+    validate_configuration(configuration=configuration)
+
+    page_size = int(configuration.get("page_size", __DEFAULT_PAGE_SIZE))
+    max_records = int(configuration.get("max_records_per_sync", "0"))
+    taxon_key = configuration.get("taxon_key", "").strip()
+    country = configuration.get("country", "").strip()
+
+    # The cursor is the offset. GBIF occurrence search exposes no stable
+    # modified-time ordering (lastInterpreted is rewritten whenever a record is
+    # reprocessed), so a time cursor would skip or duplicate. The offset is a
+    # true resume point for a bounded query as long as the result ordering is
+    # stable for the duration of the backfill, which GBIF guarantees within the
+    # deep-paging cap. The offset is advanced per record, not per page, so a run
+    # stopped mid-page by max_records_per_sync resumes on the exact next record
+    # rather than skipping the remainder of the page.
+    offset = int(state.get("offset", 0))
+
+    log.info(
+        f"Syncing GBIF occurrences from offset {offset} "
+        f"(page size {page_size}, record limit {max_records or 'none'}, "
+        f"taxon_key {taxon_key or 'any'}, country {country or 'any'})"
+    )
+
+    record_count = 0
+    limit_reached = False
+    reported_total = False
+
+    while offset < __OFFSET_CAP:
+        # Never request past the deep-paging cap: offset + limit must stay <=
+        # __OFFSET_CAP or the API returns HTTP 400.
+        effective_limit = min(page_size, __OFFSET_CAP - offset)
+        url = build_url(offset, effective_limit, taxon_key, country)
+        response = get_api_response(url)
+
+        # The first response carries the total match count. When it exceeds the
+        # deep-paging cap, offset pagination cannot reach the whole set, so warn
+        # loudly rather than silently deliver a truncated table.
+        if not reported_total:
+            total = response.get("count", 0)
+            log.info(f"GBIF reports {total} occurrences match this query")
+            if total > __OFFSET_CAP:
+                log.warning(
+                    f"The query matches {total} occurrences but GBIF only allows paging "
+                    f"through the first {__OFFSET_CAP}. Only those are reachable here; "
+                    "narrow the query with taxon_key or country to sync the rest."
+                )
+            reported_total = True
+
+        results = response.get("results", [])
+
+        for record in results:
+            gbif_id = record.get("gbifID")
+
+            # A record with no gbifID cannot be keyed in the destination. Skip it
+            # loudly rather than upserting a null key.
+            if gbif_id is None:
+                log.warning("Skipping a record with no gbifID")
+                offset += 1
+                continue
+
+            flattened = flatten_occurrence(record)
+
+            # The 'upsert' operation is used to insert or update data in the destination table.
+            # The first argument is the name of the destination table.
+            # The second argument is a dictionary containing the record to be upserted.
+            op.upsert(table="occurrence", data=flattened)
+
+            record_count += 1
+            offset += 1
+
+            if record_count % __CHECKPOINT_INTERVAL == 0:
+                # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
+                # from the correct position in case of next sync or interruptions.
+                # You should checkpoint even if you are not using incremental sync, as it tells Fivetran it is safe to write to destination.
+                # For large datasets, checkpoint regularly (e.g., every N records) not only at the end.
+                # Learn more about how and where to checkpoint by reading our best practices documentation
+                # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
+                op.checkpoint(state={"offset": offset})
+                log.info(f"Checkpointed after {record_count} records at offset {offset}")
+
+            # Because the offset advances per record, max_records_per_sync is a
+            # true ceiling: the run stops on the exact record and the next sync
+            # resumes on the following one, with no page remainder skipped.
+            if max_records and record_count >= max_records:
+                log.warning(
+                    f"Reached the configured max_records_per_sync limit of {max_records}. "
+                    f"Synced {record_count} records through offset {offset}. "
+                    "The next sync resumes immediately after it."
+                )
+                limit_reached = True
+                break
+
+        if limit_reached:
+            break
+
+        # endOfRecords marks the last page for this query. An empty page is the
+        # same terminal signal and guards against a missing flag.
+        if response.get("endOfRecords") or not results:
+            break
+
+    if offset >= __OFFSET_CAP and not limit_reached:
+        log.warning(
+            f"Stopped at the GBIF deep-paging cap of {__OFFSET_CAP} records. "
+            "Narrow the query to reach occurrences beyond it."
+        )
+
+    # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
+    # from the correct position in case of next sync or interruptions.
+    # You should checkpoint even if you are not using incremental sync, as it tells Fivetran it is safe to write to destination.
+    # For large datasets, checkpoint regularly (e.g., every N records) not only at the end.
+    # Learn more about how and where to checkpoint by reading our best practices documentation
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
+    op.checkpoint(state={"offset": offset})
+
+    log.info(f"Sync complete. Upserted {record_count} occurrences up to offset {offset}")
+
+
+connector = Connector(update=update, schema=schema)
+
+if __name__ == "__main__":
+    with open("configuration.json", "r") as f:
+        configuration = json.load(f)
+    connector.debug(configuration=configuration)

--- a/gbif/connector.py
+++ b/gbif/connector.py
@@ -301,7 +301,7 @@ def update(configuration: dict, state: dict):
         state: A dictionary containing state information from previous runs
         The state dictionary is empty for the first sync or for any full re-sync
     """
-    log.warning("Example: Source Examples - GBIF Occurrences")
+    log.warning("Example: Source Examples : GBIF Occurrences")
 
     validate_configuration(configuration=configuration)
 


### PR DESCRIPTION
## What this connector does

Syncs species occurrence records from the public [GBIF occurrence search API](https://techdocs.gbif.org/en/openapi/v1/occurrence) into a single `occurrence` table keyed on `gbif_id`. GBIF (Global Biodiversity Information Facility) aggregates biodiversity data from thousands of institutions; each record is one observation or specimen of a species with its taxonomy, coordinates, and event date. The API is public and requires no credentials.

## Hazards found while profiling the live API (2026-07-29)

Profiling was done against the live endpoint before any code was written. What it found:

- Hazard #8 -- reserved SQL keywords (the designated hazard for this connector, exercised). The occurrence record carries `class` (e.g. "Magnoliopsida") and `order` (e.g. "Rosales") as top-level taxonomic fields, and a numeric `key` that duplicates `gbifID`. All three are reserved SQL keywords that fail an unquoted `CREATE TABLE` on most warehouses. Handled by renaming `class` and `order` to `taxon_class` and `taxon_order` at the source, and dropping `key` in favour of the string `gbif_id` primary key. Verified by the shared contract's static reserved-word check and a live DuckDB `CREATE TABLE` of the delivered schema.
- Hazard #2 -- deep-paging offset cap (also exercised). GBIF caps pagination at `offset + limit <= 100000`; live, `offset=100001` returns HTTP 400, and the unfiltered corpus reports 3,909,145,444 matches. A connector that paged blindly would either 400 mid-sync or silently deliver a truncated table. Handled by reading the total `count` on the first page, warning loudly when it exceeds the cap, stopping at the cap, and shrinking the final page's limit so no request is ever issued past `offset + limit = 100000`. The remedy for a larger set is to narrow the query with `taxon_key` or `country`. Both debug runs below show the cap warning firing live.
- Cap + offset off-by-N (the NVD class). Because the cursor is the offset and the connector has a per-sync record cap, a naive implementation that advanced the offset by a full page size after a mid-page stop would skip the page remainder forever. Handled by advancing the offset per record, so `max_records_per_sync` is a true ceiling. Covered by a drain regression test asserting repeated bounded syncs cover every record exactly once.
- Cursor design. Occurrence search exposes no stable modified-time ordering (`lastInterpreted` is rewritten on reprocessing; a Jan-2024 window returned count 0), so a time cursor would skip or duplicate. The offset is the resume cursor for a bounded query. Hazard #1 (inclusive-range-to-compound-cursor) does not apply: there is no inclusive time-range filter driving the cursor.
- Page size. The API caps `limit` at 300 regardless of what is requested; `page_size` is validated to 1-300.
- Config completeness. Every configuration key (`page_size`, `max_records_per_sync`, `taxon_key`, `country`) is validated before any request; numeric checks reject zero where a positive integer is required; the `country` and `taxon_key` filters are URL-encoded via `urllib.parse`. There is no hostname config and no boolean flag, so those hazard classes do not apply.

## Debug evidence

Two live `fivetran debug` runs. The second resumes from the first's checkpoint (offset 150 -> offset 300) rather than restarting:

```
================================================================================
DEBUG RUN 1 of 2 — fresh sync (no prior state)
command: fivetran debug --configuration configuration_local.json
config:  page_size=100, max_records_per_sync=150, taxon_key=(any), country=(any)
================================================================================
29-Jul 17:16:56.801 INFO  › debugging connector at: .../contributions/gbif
29-Jul 17:16:58.483 INFO  previous state:
{}
29-Jul 17:16:59.774 INFO  calling schema()
29-Jul 17:16:59.785 INFO  schema change detected: tester.occurrence
29-Jul 17:16:59.791 INFO  table created: tester.occurrence
29-Jul 17:16:59.798 INFO  calling update()
29-Jul 17:16:59.798 WARNING Example: Source Examples - GBIF Occurrences
29-Jul 17:16:59.798 INFO  Syncing GBIF occurrences from offset 0 (page size 100, record limit 150, taxon_key any, country any)
29-Jul 17:17:02.466 INFO  GBIF reports 3909145444 occurrences match this query
29-Jul 17:17:02.467 WARNING The query matches 3909145444 occurrences but GBIF only allows paging through the first 100000. Only those are reachable here; narrow the query with taxon_key or country to sync the rest.
29-Jul 17:17:06.005 WARNING Reached the configured max_records_per_sync limit of 150. Synced 150 records through offset 150. The next sync resumes immediately after it.
29-Jul 17:17:06.010 INFO  Sync complete. Upserted 150 occurrences up to offset 150
29-Jul 17:17:06.442 INFO  checkpoint recorded: {"offset": 150}
29-Jul 17:17:06.442 INFO  Final checkpoint: committing any remaining operations
29-Jul 17:17:06.443 INFO  SYNC SUCCEEDED — total elapsed 00:00:07
Operation       | Counts
----------------+------------
Upserts         | 150
Updates         | 0
Deletes         | 0
Truncates       | 0
Schema changes  | 1
Checkpoints     | 1
29-Jul 17:17:09.012 INFO  peak memory used by the debug process: 0.06 GB


================================================================================
DEBUG RUN 2 of 2 — RESUME (reads run 1 checkpoint from files/state.json)
command: fivetran debug --configuration configuration_local.json
================================================================================
29-Jul 17:17:17.187 INFO  › debugging connector at: .../contributions/gbif
29-Jul 17:17:18.535 INFO  previous state:
{"offset": 150}
29-Jul 17:17:19.802 INFO  calling schema()
29-Jul 17:17:19.813 INFO  schema change detected: tester.occurrence
29-Jul 17:17:19.824 INFO  calling update()
29-Jul 17:17:19.824 WARNING Example: Source Examples - GBIF Occurrences
29-Jul 17:17:19.824 INFO  Syncing GBIF occurrences from offset 150 (page size 100, record limit 150, taxon_key any, country any)
29-Jul 17:17:22.618 INFO  GBIF reports 3909145444 occurrences match this query
29-Jul 17:17:22.618 WARNING The query matches 3909145444 occurrences but GBIF only allows paging through the first 100000. Only those are reachable here; narrow the query with taxon_key or country to sync the rest.
29-Jul 17:17:25.649 WARNING Reached the configured max_records_per_sync limit of 150. Synced 150 records through offset 300. The next sync resumes immediately after it.
29-Jul 17:17:25.664 INFO  Sync complete. Upserted 150 occurrences up to offset 300
29-Jul 17:17:26.121 INFO  checkpoint recorded: {"offset": 300}
29-Jul 17:17:26.122 INFO  Final checkpoint: committing any remaining operations
29-Jul 17:17:26.122 INFO  SYNC SUCCEEDED — total elapsed 00:00:07
Operation       | Counts
----------------+------------
Upserts         | 150
Updates         | 0
Deletes         | 0
Truncates       | 0
Schema changes  | 1
Checkpoints     | 1
29-Jul 17:17:28.508 INFO  peak memory used by the debug process: 0.06 GB

--------------------------------------------------------------------------------
RESUME PROOF: run 1 checkpointed at offset 150; run 2 loaded that as its previous
state ({"offset": 150}), synced FROM offset 150 (not from 0), and advanced the
cursor to offset 300. The second run resumed; it did not restart.

HAZARD #2 (deep-paging offset cap) exercised LIVE in both runs: GBIF reports
3,909,145,444 matches for the unfiltered query, and the connector warned that only
the first 100,000 are reachable by offset paging rather than silently delivering a
truncated table. Verified separately during profiling: offset=100001 returns HTTP
400.
--------------------------------------------------------------------------------

```

## Checklist

- SDK v2+ (`op.upsert` / `op.checkpoint` called directly, no `yield op.`)
- `validate_configuration()` called first in `update()`
- `configuration.json` holds placeholder values only; no credentials in the diff
- Public API, no authentication
- Passes the shared connector contract (universal rules incl. reserved-word static + live DuckDB CREATE TABLE) plus source-specific tests for the offset cursor, per-record offset advance, deep-paging cap, and the drain test
- 8-stage pre-submission gate passed (flake8, black --line-length=99, credential scrub)
- Ships three files: `connector.py`, `configuration.json`, `README.md`
