### PR TITLE
feature(connectors/aveva_pi_jdbc): add AVEVA PI JDBC connectivity check

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ For SDK installation and setup, visit the main [Fivetran Connector SDK repositor
 - **[apache_hive/using_sqlalchemy](https://github.com/fivetran/community_connectors/tree/main/apache_hive/using_sqlalchemy)** - Sync data from Apache Hive using SQLAlchemy with PyHive
 - **[arango_db](https://github.com/fivetran/community_connectors/tree/main/arango_db)** - Sync document and edge collections from ArangoDB multi-model database
 - **[aveva_pi](https://github.com/fivetran/community_connectors/tree/main/aveva_pi)** - Sync asset hierarchy and time-series data from AVEVA PI (formerly OSIsoft PI) via PI Web API
+- **[aveva_pi_jdbc](https://github.com/fivetran/community_connectors/tree/main/aveva_pi_jdbc)** - Proof-of-concept JDBC connectivity check for AVEVA PI (formerly OSIsoft PI) via the PI SQL Client JDBC driver
 - **[cassandra](https://github.com/fivetran/community_connectors/tree/main/cassandra)** - Connect and sync data from Cassandra database
 - **[clickhouse](https://github.com/fivetran/community_connectors/tree/main/clickhouse)** - Sync data from ClickHouse database
 - **[couchbase_capella](https://github.com/fivetran/community_connectors/tree/main/couchbase_capella)** - Sync data from Couchbase Capella

--- a/aveva_pi_jdbc/README.md
+++ b/aveva_pi_jdbc/README.md
@@ -1,0 +1,159 @@
+# AVEVA PI JDBC Connectivity Check
+
+## Connector overview
+
+This connector is a **proof of concept**, not a data sync. It validates that a
+JRE and AVEVA's proprietary **PI SQL Client JDBC Driver** can be installed and
+authenticated against from inside the Hosted Connector SDK's Linux (amd64)
+container — the one blocker that ruled out AVEVA's ODBC driver, which is
+Windows-only.
+
+On each run it opens an authenticated JDBC connection to PI SQL Data Access
+Server (DAS), reads standard JDBC driver/server metadata, and upserts a single
+row recording that the connection succeeded. It does not sync any PI data
+(elements, attributes, event frames, recorded values, etc.).
+
+For a full data sync connector, see the REST-based [`aveva_pi`](../aveva_pi)
+connector in this repo, which uses PI Web API instead of JDBC. A JDBC-based
+version of that full sync is tracked separately (RD-1262718) and would build on
+the connectivity layer proven here.
+
+## Why JDBC instead of ODBC
+
+AVEVA's PI SQL Client ODBC driver only ships for Windows. The Hosted Connector
+SDK runs on Linux amd64, so ODBC cannot be used.
+
+AVEVA's **PI JDBC Driver 2018 or later** is a pure-Java, platform-agnostic
+driver — no native/COM-wrapper dependency (earlier, pre-2018 versions did
+depend on a COM-wrapper library and are not platform-agnostic; do not use
+those). Both drivers connect to the same backend, PI SQL DAS, over HTTPS or
+net.tcp — the driver only changes what runs on the client side.
+
+**Use PI JDBC Driver 2018 or later.** This connector has not been tested
+against earlier versions.
+
+## Obtaining the driver
+
+AVEVA distributes `PIJDBCDriver.jar` only through the licensed AVEVA/OSIsoft
+customer support portal (`techsupport.osisoft.com`), gated behind an active PI
+System support entitlement. It is not published to Maven Central or any other
+public repository, and this repo cannot bundle it.
+
+Before running or deploying this connector:
+1. Download `PIJDBCDriver.jar` from your organization's AVEVA/OSIsoft customer
+   portal account.
+2. Place it at `drivers/PIJDBCDriver.jar` in this connector's project
+   directory.
+3. Confirm with your AVEVA license terms whether the jar may be copied into a
+   container image you don't directly control (such as Fivetran's Hosted
+   Connector SDK runtime) — this is a licensing question this repo does not
+   answer.
+
+`drivers/installation.sh` fails fast with an explanatory error if the jar is
+missing.
+
+## Requirements
+
+- [Supported Python versions](https://github.com/fivetran/community_connectors/blob/main/README.md#requirements)
+- Operating system: Linux amd64 (Hosted Connector SDK runtime)
+- `drivers/PIJDBCDriver.jar` — AVEVA PI JDBC Driver 2018 or later (see above)
+- PI SQL Data Access Server (DAS), reachable over the network from the
+  connector host
+- A PI user account with read access to the target AF database, authenticated
+  via **username/password** — not Integrated Security/SSPI. SSPI is a
+  Windows-only OS API and is unavailable in this Linux container. Your DAS
+  must be configured to accept non-SSPI authentication for this to work.
+
+## Getting started
+
+Refer to the [Connector SDK Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
+
+> Note: Ensure you have updated `configuration.json` and placed
+> `drivers/PIJDBCDriver.jar` before running `fivetran debug`. See
+> [Obtaining the driver](#obtaining-the-driver) and
+> [Configuration file](#configuration-file).
+
+## Configuration file
+
+```json
+{
+  "das_host": "<PI_SQL_DAS_HOST>",
+  "af_server": "<PI_AF_SERVER_NAME>",
+  "af_database": "<PI_AF_DATABASE_NAME>",
+  "username": "<PI_USERNAME>",
+  "password": "<PI_PASSWORD>"
+}
+```
+
+| Key | Required | Description |
+|---|---|---|
+| `das_host` | Yes | Hostname (and port, if non-default) of the PI SQL Data Access Server |
+| `af_server` | Yes | Name of the PI AF Server to connect through |
+| `af_database` | Yes | Name of the PI AF Database to connect to |
+| `username` | Yes | PI user account with read access to the target AF database |
+| `password` | Yes | Password for the PI user account |
+
+> Note: When submitting connector code as a Community Connector, ensure `configuration.json` has placeholder values. When deploying, do not check this file into version control to protect credentials.
+
+## Known unknowns — read before using against a real DAS
+
+This connector was written and reviewed without access to AVEVA's gated
+"Connection string format" documentation. Two things should be confirmed
+against that doc (or AVEVA support) before pointing this at a real DAS:
+
+- The exact connection-string property names for username/password
+  authentication in `client.py`'s `build_jdbc_url()`. It currently assumes
+  AVEVA's OLEDB-style provider grammar (`AF Server=...;AF Database=...;`)
+  extends naturally to non-SSPI credentials, but the specific property names
+  for that (equivalent to `Integrated Security=SSPI`) were not independently
+  verified.
+- Whether your DAS instance is configured to accept non-SSPI authentication at
+  all — some PI environments may only allow Integrated Security.
+
+## Authentication
+
+The connector uses username/password authentication over JDBC, passed via
+`jaydebeapi.connect()`'s auth parameter. See
+[Known unknowns](#known-unknowns--read-before-using-against-a-real-das) above.
+
+## Data handling
+
+- Schema: a single diagnostic table, `jdbc_connection_check`.
+- Each run records the JDBC driver name/version and PI SQL DAS product
+  name/version (via standard `java.sql.DatabaseMetaData`, not a PI-specific
+  query) as proof the connection authenticated successfully.
+
+## Error handling
+
+- Missing configuration values raise `ValueError` immediately (see
+  `validate_configuration()` in `connector.py`).
+- A missing `drivers/PIJDBCDriver.jar` raises `FileNotFoundError` with
+  instructions (see `connect()` in `client.py`).
+- Connection/authentication failures propagate from `jaydebeapi.connect()`
+  uncaught — there is no retry logic, since this connector's only job is to
+  prove connectivity once per run.
+
+## Tables created
+
+### JDBC connection check
+
+| Column | Type | Primary key |
+|---|---|---|
+| `checked_at` | UTC_DATETIME | Yes |
+| `connected` | BOOLEAN | |
+| `driver_name` | STRING | |
+| `driver_version` | STRING | |
+| `database_product_name` | STRING | |
+| `database_product_version` | STRING | |
+
+## Additional files
+
+- **`client.py`** — JDBC connection setup (`connect()`) and standard JDBC
+  metadata lookup (`get_driver_and_server_info()`).
+- **`drivers/installation.sh`** — installs a headless JRE and verifies the
+  AVEVA-supplied driver jar is present, before this connector's Python
+  dependencies are installed.
+
+## Additional considerations
+
+The examples provided are intended to help you effectively use Fivetran's Connector SDK. While we've tested the code, Fivetran cannot be held responsible for any unexpected or negative consequences that may arise from using these examples. For inquiries, please reach out to our Support team.

--- a/aveva_pi_jdbc/client.py
+++ b/aveva_pi_jdbc/client.py
@@ -1,0 +1,100 @@
+# For locating the AVEVA-supplied driver jar relative to this file
+import os
+
+# Bridges Python to the JVM-hosted AVEVA PI SQL Client JDBC driver
+import jaydebeapi
+
+# For enabling logs in the connector
+from fivetran_connector_sdk import Logging as log
+
+# Driver class name shipped inside AVEVA's PIJDBCDriver.jar
+# (PI JDBC Driver Administrator Guide, AVEVA/OSIsoft customer portal).
+__DRIVER_CLASS = "com.osisoft.jdbc.Driver"
+
+# drivers/installation.sh expects the AVEVA-supplied jar at this path; it cannot be
+# committed to this repo because AVEVA distributes it only through a licensed,
+# access-controlled customer portal. See the README's "Obtaining the driver" section.
+__DRIVER_JAR_PATH = os.path.join(os.path.dirname(__file__), "drivers", "PIJDBCDriver.jar")
+
+
+def build_jdbc_url(configuration: dict) -> str:
+    """
+    Build the PI SQL Client JDBC connection URL.
+
+    NOTE: AVEVA's JDBC driver reuses the PI OLEDB-style provider connection-string
+    grammar after the host segment (e.g. "AF Server=...;AF Database=...;"). This
+    repo could not independently verify the exact property names against AVEVA's
+    gated "Connection string format" documentation, since that page requires an
+    active PI System customer portal login. Confirm this against that doc (or
+    AVEVA support) before pointing this connector at a real PI SQL DAS instance.
+
+    Args:
+        configuration: a dictionary that holds the configuration settings for the connector.
+    Returns:
+        A jdbc:pisql:// connection URL string.
+    """
+    das_host = configuration["das_host"]
+    af_server = configuration["af_server"]
+    af_database = configuration["af_database"]
+    return f"jdbc:pisql://{das_host}/AF Server={af_server};AF Database={af_database};"
+
+
+def connect(configuration: dict):
+    """
+    Open an authenticated JDBC connection to PI SQL DAS.
+
+    Uses username/password authentication rather than SSPI/Integrated Security.
+    SSPI is a Windows-only OS API and is not available inside the Linux-based
+    Hosted Connector SDK container, so a DAS that only accepts Integrated
+    Security cannot be reached from here — it must be configured to also accept
+    username/password auth.
+
+    Args:
+        configuration: a dictionary that holds the configuration settings for the connector.
+    Returns:
+        An open jaydebeapi.Connection.
+    Raises:
+        FileNotFoundError: if the AVEVA-supplied driver jar is missing from drivers/.
+    """
+    if not os.path.exists(__DRIVER_JAR_PATH):
+        raise FileNotFoundError(
+            f"AVEVA PI JDBC driver jar not found at '{__DRIVER_JAR_PATH}'. "
+            "AVEVA distributes PIJDBCDriver.jar only through the licensed AVEVA/OSIsoft "
+            "customer support portal, so it cannot be bundled with this connector. "
+            "Download it from your portal account and place it at "
+            "'drivers/PIJDBCDriver.jar' before running or deploying this connector. "
+            "See the README's 'Obtaining the driver' section."
+        )
+
+    jdbc_url = build_jdbc_url(configuration)
+    log.info(f"Connecting to PI SQL DAS at '{configuration['das_host']}'")
+    return jaydebeapi.connect(
+        __DRIVER_CLASS,
+        jdbc_url,
+        [configuration["username"], configuration["password"]],
+        __DRIVER_JAR_PATH,
+    )
+
+
+def get_driver_and_server_info(conn) -> dict:
+    """
+    Read standard JDBC DatabaseMetaData from an open connection.
+
+    Deliberately uses the generic JDBC metadata API rather than a PI-specific SQL
+    query, since this repo has not independently verified PI SQL Client's query
+    schema (table/view names). This is enough to prove the driver loaded and the
+    connection authenticated successfully.
+
+    Args:
+        conn: an open jaydebeapi.Connection.
+    Returns:
+        A dict with driver_name, driver_version, database_product_name and
+        database_product_version.
+    """
+    metadata = conn.jconn.getMetaData()
+    return {
+        "driver_name": metadata.getDriverName(),
+        "driver_version": metadata.getDriverVersion(),
+        "database_product_name": metadata.getDatabaseProductName(),
+        "database_product_version": metadata.getDatabaseProductVersion(),
+    }

--- a/aveva_pi_jdbc/configuration.json
+++ b/aveva_pi_jdbc/configuration.json
@@ -1,0 +1,7 @@
+{
+  "das_host": "<PI_SQL_DAS_HOST>",
+  "af_server": "<PI_AF_SERVER_NAME>",
+  "af_database": "<PI_AF_DATABASE_NAME>",
+  "username": "<PI_USERNAME>",
+  "password": "<PI_PASSWORD>"
+}

--- a/aveva_pi_jdbc/connector.py
+++ b/aveva_pi_jdbc/connector.py
@@ -1,0 +1,142 @@
+"""AVEVA PI JDBC connectivity check.
+
+Scope: this connector validates ONLY that a JRE plus AVEVA's PI SQL Client JDBC
+driver can be installed and authenticated against, from inside the Hosted
+Connector SDK's Linux container. It does not sync any PI data (elements,
+attributes, event frames, recorded values, etc.) — see the REST-based `aveva_pi`
+connector in this repo for a full data sync implementation over PI Web API.
+
+This exists to de-risk the JDBC connectivity path (JRE install via
+drivers/installation.sh, driver loading, non-SSPI authentication) before
+building a full JDBC-based table sync on top of it.
+
+See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
+and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+"""
+
+# For reading configuration from a JSON file
+import json
+
+# For recording when the connectivity check ran
+from datetime import datetime, timezone
+
+# Import required classes from fivetran_connector_sdk
+from fivetran_connector_sdk import Connector
+
+# For enabling logs in the connector
+from fivetran_connector_sdk import Logging as log
+
+# For supporting data operations like upsert() and checkpoint()
+from fivetran_connector_sdk import Operations as op
+
+# Local module: JDBC connection setup and driver metadata lookup
+from client import connect, get_driver_and_server_info
+
+
+def validate_configuration(configuration: dict):
+    """
+    Validate the configuration dictionary to ensure it contains all required parameters.
+    This function is called at the start of the update method to ensure that the
+    connector has all necessary configuration values.
+    Args:
+        configuration: a dictionary that holds the configuration settings for the connector.
+    Raises:
+        ValueError: if any required configuration parameter is missing or blank.
+    """
+    required = ("das_host", "af_server", "af_database", "username", "password")
+    for key in required:
+        val = configuration.get(key, "")
+        if not val:
+            raise ValueError(f"Missing or empty required configuration key: '{key}'")
+        if val.startswith("<"):
+            raise ValueError(
+                f"Required configuration key '{key}' still contains a placeholder value. "
+                "Replace it with a real value before running the connector."
+            )
+
+
+def schema(configuration: dict):
+    """
+    Define the schema function which lets you configure the schema your connector delivers.
+    See the technical reference documentation for more details on the schema function:
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
+    Args:
+        configuration: a dictionary that holds the configuration settings for the connector.
+    """
+    # A single diagnostic table proving the JDBC connection was established and
+    # authenticated. Not a real data table.
+    return [
+        {
+            "table": "jdbc_connection_check",
+            "primary_key": ["checked_at"],
+            "columns": {
+                "checked_at": "UTC_DATETIME",
+                "connected": "BOOLEAN",
+            },
+        },
+    ]
+
+
+def update(configuration: dict, state: dict):
+    """
+    Define the update function, which is a required function, and is called by Fivetran during each sync.
+    See the technical reference documentation for more details on the update function
+    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    Args:
+        configuration: A dictionary containing connection details
+        state: A dictionary containing state information from previous runs
+        The state dictionary is empty for the first sync or for any full re-sync
+    """
+    log.warning("Example: Connectors Example : Aveva PI (JDBC connectivity check)")
+
+    # Validate the configuration to ensure it contains all required values.
+    validate_configuration(configuration=configuration)
+
+    # Open an authenticated JDBC connection via the AVEVA-supplied driver.
+    conn = connect(configuration)
+    try:
+        info = get_driver_and_server_info(conn)
+        log.info(
+            f"Connected via {info['driver_name']} {info['driver_version']} "
+            f"to {info['database_product_name']} {info['database_product_version']}"
+        )
+        # The 'upsert' operation is used to insert or update data in the destination table.
+        # The first argument is the name of the destination table.
+        # The second argument is a dictionary containing the record to be upserted.
+        op.upsert(
+            table="jdbc_connection_check",
+            data={
+                "checked_at": datetime.now(timezone.utc),
+                "connected": True,
+                **info,
+            },
+        )
+    finally:
+        conn.close()
+
+    # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
+    # from the correct position in case of next sync or interruptions.
+    # You should checkpoint even if you are not using incremental sync, as it tells Fivetran it is safe to write to destination.
+    op.checkpoint(state)
+
+
+# Create the connector object using the schema and update functions
+connector = Connector(update=update, schema=schema)
+
+# Check if the script is being run as the main module.
+# This is Python's standard entry method allowing your script to be run directly from the command line or IDE 'run' button.
+#
+# IMPORTANT: The recommended way to test your connector is using the Fivetran debug command:
+#   fivetran debug
+#
+# This local testing block is provided as a convenience for quick debugging during development,
+# such as using IDE debug tools (breakpoints, step-through debugging, etc.).
+# Note: This method is not called by Fivetran when executing your connector in production.
+# Always test using 'fivetran debug' prior to finalizing and deploying your connector.
+if __name__ == "__main__":
+    # Open the configuration.json file and load its contents
+    with open("configuration.json", "r") as f:
+        configuration = json.load(f)
+
+    # Test the connector locally
+    connector.debug(configuration=configuration)

--- a/aveva_pi_jdbc/drivers/installation.sh
+++ b/aveva_pi_jdbc/drivers/installation.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Installs the JRE required by jaydebeapi/JPype to load AVEVA's PI SQL Client
+# JDBC driver inside the Hosted Connector SDK's Linux container.
+#
+# The Connector SDK runtime executes this script as root, before installing
+# this connector's Python dependencies from requirements.txt (see
+# connector_sdk_runner/init.sh in the fivetran/engineering monorepo).
+set -euo pipefail
+
+JAR_PATH="$(dirname "$0")/PIJDBCDriver.jar"
+
+if [ ! -f "$JAR_PATH" ]; then
+  echo "ERROR: $JAR_PATH not found." >&2
+  echo "AVEVA's PI SQL Client JDBC driver is licensed software distributed only" >&2
+  echo "through the AVEVA/OSIsoft customer support portal — it cannot be" >&2
+  echo "committed to this public repository. Download PIJDBCDriver.jar from" >&2
+  echo "your portal account and place it at drivers/PIJDBCDriver.jar before" >&2
+  echo "packaging this connector with 'fivetran deploy'." >&2
+  exit 1
+fi
+
+apt-get update
+apt-get install -y --no-install-recommends default-jre-headless
+rm -rf /var/lib/apt/lists/*
+
+echo "JRE installed: $(java -version 2>&1 | head -1)"

--- a/aveva_pi_jdbc/requirements.txt
+++ b/aveva_pi_jdbc/requirements.txt
@@ -1,0 +1,9 @@
+# JayDeBeApi bridges Python to the AVEVA-supplied PI SQL Client JDBC driver via
+# a JPype-embedded JVM. JPype1 is JayDeBeApi's runtime dependency for starting
+# and calling into that JVM.
+#
+# Note: The following packages are pre-installed in the base environment
+# and should not be included in this file:
+#   fivetran_connector_sdk:latest, requests:2.33.0, grpcio:1.78.0, grpcio-tools:1.78.0
+JayDeBeApi==1.2.3
+JPype1==1.5.0


### PR DESCRIPTION
### Description

Adds `aveva_pi_jdbc/`, a proof-of-concept connector validating that a JRE plus AVEVA's **PI SQL Client JDBC Driver (2018 or later)** can be installed and authenticated against from inside the Hosted Connector SDK's Linux (amd64) container.

Context: AVEVA's PI SQL Client **ODBC** driver is Windows-only, which is why the existing [`aveva_pi`](https://github.com/fivetran/community_connectors/tree/main/aveva_pi) connector uses PI Web API (REST) instead. The **JDBC** driver (2018+) is pure Java and platform-agnostic — no native/COM dependency — so it can run under a Linux JRE. This connector proves that path end-to-end (JRE install via `drivers/installation.sh`, driver loading, non-SSPI username/password authentication) without attempting a full data sync.

Scope is intentionally narrow: `update()` opens one JDBC connection, reads standard `java.sql.DatabaseMetaData` (driver + server name/version — not PI-specific SQL, since this repo hasn't independently verified PI SQL Client's query schema), and upserts a single diagnostic row. It does not sync elements, attributes, event frames, or recorded values. A full JDBC-based data sync is tracked separately as a follow-up.

**Known unknown, called out in the README:** the exact connection-string property names for non-SSPI (username/password) authentication were not independently verified — AVEVA's "Connection string format" documentation sits behind a licensed customer-portal login this environment doesn't have access to. This should be confirmed against that doc (or AVEVA support) before pointing the connector at a real PI SQL DAS.

**Driver distribution:** AVEVA distributes `PIJDBCDriver.jar` only through their gated customer support portal (not Maven Central or any public registry), so it isn't and can't be bundled in this repo. `drivers/installation.sh` fails fast with instructions if the jar isn't present at `drivers/PIJDBCDriver.jar`.

### Validation

`fivetran debug` was **not** run against a real PI SQL DAS — this environment has neither a licensed `PIJDBCDriver.jar` nor a reachable AVEVA PI System/DAS instance to test against. What was validated locally instead:

- `python3 -m py_compile` on `connector.py` and `client.py` — no syntax errors.
- `black --line-length 99` — no formatting changes needed.
- `flake8` — clean, no lint findings.

This is disclosed as a real gap, not glossed over: someone with access to a licensed driver jar and a live PI SQL DAS should run `fivetran debug` before this is treated as verified end-to-end.

### Checklist

- [ ] **Connector code change:** I ran `fivetran debug` and attached sanitized proof of a successful run. *(Not done — see Validation above; no licensed driver/DAS access in this environment.)*
- [x] **New connector:** I added a connector-level `README.md` with the relevant template sections and listed the connector in the root `README.md`.
- [x] **All contributions:** I confirmed that the change and its validation evidence contain no credentials, personal data, customer information, or other sensitive values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)