### PR TITLE
fix(connector_sdk) : Added a note in the README.md for the customer on how to resolve the error 

### DIFF
--- a/ibm_informix/ibm_informix_using_ibm_db/README.md
+++ b/ibm_informix/ibm_informix_using_ibm_db/README.md
@@ -49,6 +49,8 @@ The connector requires the following configuration parameters:
 }
 ```
 
+> Important: If you see `SQL30081N`, review the DRDA listener guidance in the [Troubleshooting](#troubleshooting) section.
+
 > Note: When submitting connector code as a community connector in the open-source [Community Connector repository](https://github.com/fivetran/community_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
 ## Requirements file
@@ -119,3 +121,16 @@ You must explicitly provide the path to the `clidriver\\bin` directory before th
     ```
 
 This ensures the connector works for local debugging on Windows and the logic is safely ignored when deployed in Fivetran's production environment.
+
+**Error: `SQL30081N` during connect (`connect` timeout or `recv` socket close)**
+
+Issue: Informix has two listener types:
+- `onsoctcp` = normal/native listener
+- `drsoctcp` = DRDA listener
+
+Some `ibm_db` connection paths require DRDA. If you point the connector to only the normal listener, `SQL30081N` can occur.
+
+Resolution:
+
+- If DRDA is already configured in Informix, set `port` in `configuration.json` to the DRDA port.
+- If DRDA is not configured, add a DRDA listener/alias in Informix first, then use that DRDA port in `configuration.json`.

--- a/ibm_informix/ibm_informix_using_ibm_db/README.md
+++ b/ibm_informix/ibm_informix_using_ibm_db/README.md
@@ -144,4 +144,4 @@ Some `ibm_db` connection paths require DRDA. If you point the connector to only 
 Resolution:
 
 - If DRDA is already configured in Informix, set `port` in `configuration.json` to the DRDA port.
-- If DRDA is not configured, add a DRDA listener/alias in Informix first, then use that DRDA port in `configuration.json`.
+- If DRDA is not configured, add a DRDA listener in Informix first, then use that DRDA port in `configuration.json`.

--- a/ibm_informix/ibm_informix_using_ibm_db/README.md
+++ b/ibm_informix/ibm_informix_using_ibm_db/README.md
@@ -49,7 +49,7 @@ The connector requires the following configuration parameters:
 }
 ```
 
-> Important: If you see `SQL30081N`, review the DRDA listener guidance in the [Troubleshooting](#troubleshooting) section.
+> Important: If you see an `SQL30081N` error, refer to the DRDA listener guidance in the [Troubleshooting](#troubleshooting) section.
 
 > Note: When submitting connector code as a community connector in the open-source [Community Connector repository](https://github.com/fivetran/community_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 

--- a/ibm_informix/ibm_informix_using_ibm_db/README.md
+++ b/ibm_informix/ibm_informix_using_ibm_db/README.md
@@ -79,7 +79,10 @@ The schema used in the example is as follows:
 ```json
 {
   "table": "sample_table",
-  "primary_key": ["tabid"]
+  "primary_key": ["tabid"],
+  "columns": {
+    "tabid": "INT"
+  }
 }
 ```
 

--- a/ibm_informix/ibm_informix_using_ibm_db/README.md
+++ b/ibm_informix/ibm_informix_using_ibm_db/README.md
@@ -93,6 +93,14 @@ The connector implements error handling for:
 - Datetime conversion issues with graceful fallback to string representation
 - Missing configuration parameters with clear error messages
 
+## Tables created
+
+The connector creates the following destination table (refer to the `schema()` function in `connector.py`):
+
+| Table          | Primary key | Columns |
+|----------------|---|---|
+| `sample_table` | `tabid` | `tabid` (`INT`) |
+
 ## Additional considerations
 
 > Note: This example was tested using the IBM Informix developer edition local server. If you face any difficulties while writing your connector, please connect with [our professional services](https://support.fivetran.com/hc/en-us/requests/new?isSdkIssue=true).

--- a/ibm_informix/ibm_informix_using_ibm_db/README.md
+++ b/ibm_informix/ibm_informix_using_ibm_db/README.md
@@ -98,7 +98,7 @@ The examples provided are intended to help you effectively use Fivetran's Connec
 
 ## Troubleshooting
 
-**Error: `ImportError: DLL load failed while importing ibm_db` on Windows**
+### ImportError: DLL load failed while importing ibm_db on Windows
 
 Issue: This error occurs on Windows because the Python interpreter cannot find the required library files (`clidriver` DLLs) needed by the `ibm_db` package.
 
@@ -122,7 +122,7 @@ You must explicitly provide the path to the `clidriver\\bin` directory before th
 
 This ensures the connector works for local debugging on Windows and the logic is safely ignored when deployed in Fivetran's production environment.
 
-**Error: `SQL30081N` during connect (`connect` timeout or `recv` socket close)**
+### SQL30081N during connect (connect timeout or recv socket close)
 
 Issue: Informix has two listener types:
 - `onsoctcp` = normal/native listener

--- a/ibm_informix/ibm_informix_using_ibm_db/README.md
+++ b/ibm_informix/ibm_informix_using_ibm_db/README.md
@@ -72,14 +72,14 @@ The connector uses username and password authentication to connect to your IBM I
 The connector:
 - Executes SQL queries against your specified table
 - Properly formats datetime values for consistent representation
-- Tracks the latest created_at timestamp to enable incremental syncs
+- Tracks the latest `created` timestamp to enable incremental syncs
 
 The schema used in the example is as follows:
 
 ```json
 {
   "table": "sample_table",
-  "primary_key": ["id"]
+  "primary_key": ["tabid"]
 }
 ```
 

--- a/ibm_informix/ibm_informix_using_ibm_db/README.md
+++ b/ibm_informix/ibm_informix_using_ibm_db/README.md
@@ -49,7 +49,7 @@ The connector requires the following configuration parameters:
 }
 ```
 
-> Important: If you see an `SQL30081N` error, refer to the DRDA listener guidance in the [Troubleshooting](#troubleshooting) section.
+> IMPORTANT: If you see an `SQL30081N` error, refer to the DRDA listener guidance in the [Troubleshooting](#troubleshooting) section.
 
 > Note: When submitting connector code as a community connector in the open-source [Community Connector repository](https://github.com/fivetran/community_connectors/tree/main), ensure the `configuration.json` file has placeholder values. When adding the connector to your production repository, ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 

--- a/ibm_informix/ibm_informix_using_ibm_db/README.md
+++ b/ibm_informix/ibm_informix_using_ibm_db/README.md
@@ -136,7 +136,7 @@ This ensures the connector works for local debugging on Windows and the logic is
 ### SQL30081N during connect (connect timeout or recv socket close)
 
 Issue: Informix has two listener types:
-- `onsoctcp` = normal/native listener
+- `onsoctcp` = normal or native listener
 - `drsoctcp` = DRDA listener
 
 Some `ibm_db` connection paths require DRDA. If you point the connector to only the normal listener, `SQL30081N` can occur.

--- a/ibm_informix/ibm_informix_using_ibm_db/connector.py
+++ b/ibm_informix/ibm_informix_using_ibm_db/connector.py
@@ -69,9 +69,7 @@ def validate_configuration(configuration: dict):
     try:
         port = int(str(configuration.get("port")).strip())
     except ValueError as value_error:
-        raise ValueError(
-            "Invalid port: must be an integer between 1 and 65535"
-        ) from value_error
+        raise ValueError("Invalid port: must be an integer between 1 and 65535") from value_error
     if port < 1 or port > 65535:
         raise ValueError("Invalid port: must be between 1 and 65535")
     configuration["port"] = port
@@ -81,9 +79,7 @@ def validate_configuration(configuration: dict):
     if len(table_name_parts) > 2 or not all(
         _is_safe_identifier(identifier_part) for identifier_part in table_name_parts
     ):
-        raise ValueError(
-            "Invalid table_name: use an unquoted identifier or schema.table format"
-        )
+        raise ValueError("Invalid table_name: use an unquoted identifier or schema.table format")
     configuration["table_name"] = table_name
 
 

--- a/ibm_informix/ibm_informix_using_ibm_db/connector.py
+++ b/ibm_informix/ibm_informix_using_ibm_db/connector.py
@@ -213,10 +213,9 @@ def update(configuration: dict, state: dict):
     data = ibm_db.fetch_assoc(stmt)
     # Iterate over the result set and upsert each record until there are no more records
     while data:
-        # The 'upsert' operation is used to insert or update the record in the destination table.
-        # The op.upsert method is called with two arguments:
-        # - The first argument is the name of the table to upsert the data into, in this case, "sample_table".
-        # - The second argument is a dictionary containing the data to be upserted,
+        # The 'upsert' operation is used to insert or update data in the destination table.
+        # The first argument is the name of the destination table.
+        # The second argument is a dictionary containing the record to be upserted.
         op.upsert(table="sample_table", data=data)
 
         # Update the last_created variable with the created value of the current record
@@ -236,22 +235,31 @@ def update(configuration: dict, state: dict):
 
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
+    # You should checkpoint even if you are not using incremental sync, as it tells Fivetran it is safe to write to destination.
+    # For large datasets, checkpoint regularly (e.g., every N records) not only at the end.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     state["last_created"] = last_created
     op.checkpoint(state)
 
 
-# This creates the connector object that will use the update function defined in this connector.py file.
+# Create the connector object using the schema and update functions
 connector = Connector(update=update, schema=schema)
 
 # Check if the script is being run as the main module.
 # This is Python's standard entry method allowing your script to be run directly from the command line or IDE 'run' button.
-# This is useful for debugging while you write your code. Note this method is not called by Fivetran when executing your connector in production.
-# Please test using the Fivetran debug command prior to finalizing and deploying your connector.
+#
+# IMPORTANT: The recommended way to test your connector is using the Fivetran debug command:
+#   fivetran debug
+#
+# This local testing block is provided as a convenience for quick debugging during development,
+# such as using IDE debug tools (breakpoints, step-through debugging, etc.).
+# Note: This method is not called by Fivetran when executing your connector in production.
+# Always test using 'fivetran debug' prior to finalizing and deploying your connector.
 if __name__ == "__main__":
-    # Open the configuration.json file and load its contents into a dictionary.
+    # Open the configuration.json file and load its contents
     with open("configuration.json", "r") as f:
         configuration = json.load(f)
-    # Adding this code to your `connector.py` allows you to test your connector by running your file directly from your IDE:
+
+    # Test the connector locally
     connector.debug(configuration=configuration)

--- a/ibm_informix/ibm_informix_using_ibm_db/connector.py
+++ b/ibm_informix/ibm_informix_using_ibm_db/connector.py
@@ -235,7 +235,7 @@ def update(configuration: dict, state: dict):
                 last_created = last_created_from_data
         data = ibm_db.fetch_assoc(stmt)
 
-    log.info("Upsert completed for all records. ")
+    log.info("Upsert completed for all records.")
 
     # Close the database connection after the operation is complete
     if "conn" in locals() and conn:

--- a/ibm_informix/ibm_informix_using_ibm_db/connector.py
+++ b/ibm_informix/ibm_informix_using_ibm_db/connector.py
@@ -23,6 +23,27 @@ import json
 from datetime import datetime
 
 
+def _is_safe_identifier(identifier: str) -> bool:
+    """
+    Check whether a SQL identifier is safe for interpolation.
+    Args:
+        identifier: The identifier to validate.
+    Returns:
+        True if the identifier is a valid unquoted SQL identifier.
+    """
+    if not identifier:
+        return False
+
+    if not (identifier[0].isalpha() or identifier[0] == "_"):
+        return False
+
+    for character in identifier:
+        if not (character.isalnum() or character in {"_", "$"}):
+            return False
+
+    return True
+
+
 def validate_configuration(configuration: dict):
     """
     Validate the configuration dictionary to ensure it contains all required parameters.
@@ -37,6 +58,24 @@ def validate_configuration(configuration: dict):
         value = configuration.get(key)
         if value is None or str(value).strip() == "":
             raise ValueError(f"Missing required configuration key: {key}")
+
+    try:
+        port = int(str(configuration.get("port")).strip())
+    except ValueError as value_error:
+        raise ValueError("Invalid port: must be an integer between 1 and 65535") from value_error
+    if port < 1 or port > 65535:
+        raise ValueError("Invalid port: must be between 1 and 65535")
+    configuration["port"] = port
+
+    table_name = str(configuration.get("table_name")).strip()
+    table_name_parts = table_name.split(".")
+    if len(table_name_parts) > 2 or not all(
+        _is_safe_identifier(identifier_part) for identifier_part in table_name_parts
+    ):
+        raise ValueError(
+            "Invalid table_name: use an unquoted identifier or schema.table format"
+        )
+    configuration["table_name"] = table_name
 
 
 # Define the schema function which lets you configure the schema your connector delivers.
@@ -161,9 +200,14 @@ def update(configuration: dict, state: dict):
 
     # The SQL query to select all records from the table specified in configuration
     # You can modify this query to suit your needs.
-    sql = f"SELECT * FROM {table_name} WHERE created > '{last_created}'"
-    # Execute the SQL query
-    stmt = ibm_db.exec_immediate(conn, sql)
+    # Use a parameter placeholder for the incremental cursor to avoid manual quote escaping in SQL text.
+    sql = f"SELECT * FROM {table_name} WHERE created > ?"
+    # Prepare the SQL template once, then bind data values separately.
+    stmt = ibm_db.prepare(conn, sql)
+    # Bind the current cursor value as a parameter so the driver handles quoting and typing safely.
+    ibm_db.bind_param(stmt, 1, last_created)
+    # Execute the prepared statement with the bound parameter value.
+    ibm_db.execute(stmt)
     # Fetch the first record from the result set
     # The ibm_db.fetch_assoc method fetches the next row from the result set as a dictionary
     data = ibm_db.fetch_assoc(stmt)

--- a/ibm_informix/ibm_informix_using_ibm_db/connector.py
+++ b/ibm_informix/ibm_informix_using_ibm_db/connector.py
@@ -69,7 +69,9 @@ def validate_configuration(configuration: dict):
     try:
         port = int(str(configuration.get("port")).strip())
     except ValueError as value_error:
-        raise ValueError("Invalid port: must be an integer between 1 and 65535") from value_error
+        raise ValueError(
+            "Invalid port: must be an integer between 1 and 65535"
+        ) from value_error
     if port < 1 or port > 65535:
         raise ValueError("Invalid port: must be between 1 and 65535")
     configuration["port"] = port
@@ -79,7 +81,9 @@ def validate_configuration(configuration: dict):
     if len(table_name_parts) > 2 or not all(
         _is_safe_identifier(identifier_part) for identifier_part in table_name_parts
     ):
-        raise ValueError("Invalid table_name: use an unquoted identifier or schema.table format")
+        raise ValueError(
+            "Invalid table_name: use an unquoted identifier or schema.table format"
+        )
     configuration["table_name"] = table_name
 
 
@@ -206,7 +210,7 @@ def update(configuration: dict, state: dict):
     # The SQL query to select all records from the table specified in configuration
     # You can modify this query to suit your needs.
     # Use a parameter placeholder for the incremental cursor to avoid manual quote escaping in SQL text.
-    sql = f"SELECT * FROM {table_name} WHERE created >= ?"
+    sql = f"SELECT * FROM {table_name} WHERE created > ?"
     # Prepare the SQL template once, then bind data values separately.
     stmt = ibm_db.prepare(conn, sql)
     # Bind the current cursor value as a parameter so the driver handles quoting and typing safely.
@@ -231,7 +235,7 @@ def update(configuration: dict, state: dict):
                 last_created = last_created_from_data
         data = ibm_db.fetch_assoc(stmt)
 
-    log.info("upserted all records from the products table")
+    log.info("Upsert completed for all records. ")
 
     # Close the database connection after the operation is complete
     if "conn" in locals() and conn:

--- a/ibm_informix/ibm_informix_using_ibm_db/connector.py
+++ b/ibm_informix/ibm_informix_using_ibm_db/connector.py
@@ -53,7 +53,14 @@ def validate_configuration(configuration: dict):
     Raises:
         ValueError: if any required configuration parameter is missing.
     """
-    required_keys = ["hostname", "port", "database", "username", "password", "table_name"]
+    required_keys = [
+        "hostname",
+        "port",
+        "database",
+        "username",
+        "password",
+        "table_name",
+    ]
     for key in required_keys:
         value = configuration.get(key)
         if value is None or str(value).strip() == "":
@@ -62,7 +69,9 @@ def validate_configuration(configuration: dict):
     try:
         port = int(str(configuration.get("port")).strip())
     except ValueError as value_error:
-        raise ValueError("Invalid port: must be an integer between 1 and 65535") from value_error
+        raise ValueError(
+            "Invalid port: must be an integer between 1 and 65535"
+        ) from value_error
     if port < 1 or port > 65535:
         raise ValueError("Invalid port: must be between 1 and 65535")
     configuration["port"] = port

--- a/ibm_informix/ibm_informix_using_ibm_db/connector.py
+++ b/ibm_informix/ibm_informix_using_ibm_db/connector.py
@@ -23,17 +23,36 @@ import json
 from datetime import datetime
 
 
+def validate_configuration(configuration: dict):
+    """
+    Validate the configuration dictionary to ensure it contains all required parameters.
+    This function is called at the start of the update method to ensure that the connector has all necessary configuration values.
+    Args:
+        configuration: a dictionary that holds the configuration settings for the connector.
+    Raises:
+        ValueError: if any required configuration parameter is missing.
+    """
+    required_keys = ["hostname", "port", "database", "username", "password", "table_name"]
+    for key in required_keys:
+        value = configuration.get(key)
+        if value is None or str(value).strip() == "":
+            raise ValueError(f"Missing required configuration key: {key}")
+
+
 # Define the schema function which lets you configure the schema your connector delivers.
 # See the technical reference documentation for more details on the schema function:
 # https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
 # The schema function takes one parameter:
 # - configuration: a dictionary that holds the configuration settings for the connector.
 def schema(configuration: dict):
-    # Check if the configuration dictionary has all the required keys
-    required_keys = ["hostname", "port", "database", "username", "password", "table_name"]
-    for key in required_keys:
-        if key not in configuration:
-            raise ValueError(f"Missing required configuration key: {key}")
+    """
+    Define the schema function which lets you configure the schema your connector delivers.
+    See the technical reference documentation for more details on the schema function:
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
+    Args:
+        configuration: a dictionary that holds the configuration settings for the connector.
+    """
+    validate_configuration(configuration)
 
     return [
         {
@@ -120,7 +139,17 @@ def get_datetime_str(date_value):
 # - state: a dictionary contains whatever state you have chosen to checkpoint during the prior sync
 # The state dictionary is empty for the first sync or for any full re-sync
 def update(configuration: dict, state: dict):
+    """
+    Define the update function, which is a required function, and is called by Fivetran during each sync.
+    See the technical reference documentation for more details on the update function
+    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    Args:
+        configuration: A dictionary containing connection details
+        state: A dictionary containing state information from previous runs
+        The state dictionary is empty for the first sync or for any full re-sync
+    """
     log.warning("Example: Source Examples - IBM Informix")
+    validate_configuration(configuration)
 
     # Connect to the IBM Informix database
     conn = connect_to_db(configuration)

--- a/ibm_informix/ibm_informix_using_ibm_db/connector.py
+++ b/ibm_informix/ibm_informix_using_ibm_db/connector.py
@@ -38,8 +38,8 @@ def schema(configuration: dict):
     return [
         {
             "table": "sample_table",  # Name of the table in the destination.
-            "primary_key": ["id"],  # Primary key column(s) for the table.
-            # No columns are defined, meaning the types will be inferred.
+            "primary_key": ["tabid"],  # Primary key column(s) for the table.
+            "columns": {"tabid": "INT"},
         }
     ]
 
@@ -126,13 +126,13 @@ def update(configuration: dict, state: dict):
     conn = connect_to_db(configuration)
     table_name = configuration.get("table_name")
 
-    # The date format of the created_at column in the database is "YYYY-MM-DD HH:MM:SS"
+    # The date format of the created column in the database is "YYYY-MM-DD HH:MM:SS"
     # Please ensure that while handling the datetime, you are using the correct format for the columns.
     last_created = state.get("last_created", "1990-01-01 00:00:00")
 
     # The SQL query to select all records from the table specified in configuration
     # You can modify this query to suit your needs.
-    sql = f"SELECT * FROM {table_name} WHERE created_at > '{last_created}'"
+    sql = f"SELECT * FROM {table_name} WHERE created > '{last_created}'"
     # Execute the SQL query
     stmt = ibm_db.exec_immediate(conn, sql)
     # Fetch the first record from the result set
@@ -146,10 +146,12 @@ def update(configuration: dict, state: dict):
         # - The second argument is a dictionary containing the data to be upserted,
         op.upsert(table="sample_table", data=data)
 
-        # Update the last_created variable with the created_at value of the current record
-        last_created_from_data = get_datetime_str(data["created_at"])
-        if last_created_from_data > last_created:
-            last_created = last_created_from_data
+        # Update the last_created variable with the created value of the current record
+        created_value = data.get("created")
+        if created_value is not None:
+            last_created_from_data = get_datetime_str(created_value)
+            if last_created_from_data > last_created:
+                last_created = last_created_from_data
         data = ibm_db.fetch_assoc(stmt)
 
     log.info("upserted all records from the products table")

--- a/ibm_informix/ibm_informix_using_ibm_db/connector.py
+++ b/ibm_informix/ibm_informix_using_ibm_db/connector.py
@@ -201,7 +201,7 @@ def update(configuration: dict, state: dict):
     # The SQL query to select all records from the table specified in configuration
     # You can modify this query to suit your needs.
     # Use a parameter placeholder for the incremental cursor to avoid manual quote escaping in SQL text.
-    sql = f"SELECT * FROM {table_name} WHERE created > ?"
+    sql = f"SELECT * FROM {table_name} WHERE created >= ?"
     # Prepare the SQL template once, then bind data values separately.
     stmt = ibm_db.prepare(conn, sql)
     # Bind the current cursor value as a parameter so the driver handles quoting and typing safely.


### PR DESCRIPTION
### Description

This PR improves the Informix  ibm_db  example with clearer DRDA guidance and updates the connector.py logic to match the current  internal-sales  Informix test instance.

#### Why this change

 ibm_db  connectivity to Informix can require the DRDA listener path depending on deployment. We saw repeated  SQL30081N  failures when listener/port assumptions were unclear.
Also, the sample table metadata in this environment differs from the original defaults ( id  /  created_at ).

#### What changed

**README ( ibm_informix/ibm_informix_using_ibm_db/README.md )**
• Added a concise troubleshooting note for  SQL30081N .
• Clarified normal listener vs DRDA listener ( onsoctcp  vs  drsoctcp ).
• Linked the important config note to the troubleshooting section.

**Connector code ( ibm_informix/ibm_informix_using_ibm_db/connector.py )**
• Updated incremental query column in  update() :
•  created_at  →  created 
• Updated state cursor handling:
• from  data["created_at"]  to  data.get("created")  flow

### Validation

<img width="1584" height="707" alt="image" src="https://github.com/user-attachments/assets/92bc480b-9de0-479f-bb70-b3b13e651678" />


### Checklist

Check only the items that apply:

- [x] **Connector code change:** I ran `fivetran debug` and attached sanitized proof of a successful run.
- [ ] **New connector:** I added a connector-level `README.md` with the relevant [template sections](https://github.com/fivetran/community_connectors/blob/main/_template_connector/README_template.md) and listed the connector in the root `README.md`.
- [x] **All contributions:** I confirmed that the change and its validation evidence contain no credentials, personal data, customer information, or other sensitive values.

See [CONTRIBUTING.md](https://github.com/fivetran/community_connectors/blob/main/CONTRIBUTING.md) for the complete contribution requirements.
